### PR TITLE
feat: add responsive design for short-height wide screens

### DIFF
--- a/src/app/styles/features.css
+++ b/src/app/styles/features.css
@@ -955,6 +955,76 @@
     }
 }
 
+/* Short height screens at desktop widths (e.g., 1272x564) */
+@media (max-height: 650px) and (min-width: 1025px) {
+    .features-enhanced {
+        padding: var(--space-16) var(--space-8);
+        min-height: auto;
+    }
+
+    .features-sticky .features-sticky-grid {
+        gap: var(--space-8);
+    }
+
+    .feature-sticky-card {
+        padding: var(--space-6);
+        margin-bottom: var(--space-4);
+    }
+
+    .features-title {
+        font-size: clamp(1.75rem, 4vw, 2.5rem);
+        margin-bottom: var(--space-3);
+    }
+
+    .features-subtitle {
+        font-size: clamp(0.95rem, 1.8vw, 1.05rem);
+        margin-bottom: var(--space-8);
+    }
+
+    .feature-title-enhanced {
+        font-size: 1.1rem;
+        margin-bottom: var(--space-3);
+    }
+
+    .feature-description-enhanced {
+        font-size: 0.9rem;
+        line-height: 1.55;
+    }
+
+    .icon-wrapper {
+        width: 56px;
+        height: 56px;
+        font-size: 1.5rem;
+        margin-bottom: var(--space-4);
+    }
+}
+
+/* Very short height screens at desktop widths */
+@media (max-height: 580px) and (min-width: 1025px) {
+    .features-enhanced {
+        padding: var(--space-12) var(--space-6);
+    }
+
+    .features-sticky .features-sticky-grid {
+        gap: var(--space-6);
+    }
+
+    .feature-sticky-card {
+        padding: var(--space-4);
+        margin-bottom: var(--space-3);
+    }
+
+    .features-title {
+        font-size: clamp(1.5rem, 3.5vw, 2rem);
+    }
+
+    .icon-wrapper {
+        width: 48px;
+        height: 48px;
+        font-size: 1.3rem;
+    }
+}
+
 /* Performance optimizations */
 @media (prefers-reduced-motion: reduce) {
     .bento-card-enhanced,
@@ -963,7 +1033,7 @@
     .progress-ring {
         transition: none;
     }
-    
+
     .progress-bar {
         animation: none;
     }

--- a/src/app/styles/footer.css
+++ b/src/app/styles/footer.css
@@ -605,6 +605,84 @@
     }
 }
 
+/* Short height screens at desktop widths (e.g., 1272x564) */
+@media (max-height: 650px) and (min-width: 1025px) {
+    .footer-container {
+        margin-top: var(--space-16);
+    }
+
+    .footer-main {
+        padding: 60px 32px;
+    }
+
+    .footer-content {
+        gap: 40px;
+    }
+
+    .footer-intro-title {
+        font-size: clamp(1.75rem, 4vw, 2.5rem);
+        margin-bottom: 28px;
+    }
+
+    .footer-cta-section {
+        padding: 24px 28px;
+        margin-bottom: 28px;
+    }
+
+    .cta-title {
+        font-size: 1.25rem;
+        margin-bottom: 10px;
+    }
+
+    .cta-subtitle {
+        font-size: 0.9rem;
+        margin-bottom: 24px;
+    }
+
+    .cta-button {
+        padding: 14px 28px;
+        font-size: 0.95rem;
+    }
+
+    .footer-bottom {
+        padding: 24px 32px;
+    }
+
+    .footer-logo-bg {
+        font-size: clamp(10rem, 12vw, 12rem);
+    }
+}
+
+/* Very short height screens at desktop widths */
+@media (max-height: 580px) and (min-width: 1025px) {
+    .footer-main {
+        padding: 48px 28px;
+    }
+
+    .footer-intro-title {
+        font-size: clamp(1.5rem, 3.5vw, 2rem);
+        margin-bottom: 20px;
+    }
+
+    .footer-cta-section {
+        padding: 20px 24px;
+        margin-bottom: 20px;
+    }
+
+    .cta-title {
+        font-size: 1.1rem;
+    }
+
+    .cta-button {
+        padding: 12px 24px;
+        font-size: 0.9rem;
+    }
+
+    .footer-bottom {
+        padding: 20px 28px;
+    }
+}
+
 /* Accessibility improvements */
 @media (prefers-reduced-motion: reduce) {
     .footer-container *,

--- a/src/app/styles/landing-page.css
+++ b/src/app/styles/landing-page.css
@@ -545,31 +545,98 @@
         min-height: 100vh;
         padding: var(--space-4) 0;
     }
-    
+
     .landing-container .hero-content {
         padding: 0 var(--space-4);
     }
-    
+
     .landing-container .hero .hero-title {
         font-size: clamp(1.5rem, 4vw, 2.5rem) !important;
         margin-bottom: var(--space-3) !important;
     }
-    
+
     .landing-container .hero-subtitle {
         font-size: clamp(0.9rem, 2vw, 1.1rem);
         margin-bottom: var(--space-6);
     }
-    
+
     .landing-container .hero-cta {
         flex-direction: row;
         max-width: 100%;
         gap: var(--space-3);
     }
-    
+
     .landing-container .hero-cta button,
     .landing-container .hero-cta a {
         min-width: auto;
         flex: 1;
+    }
+}
+
+/* Short height screens (like small laptops: 1272x564, etc.) */
+@media (max-height: 650px) and (min-width: 1025px) {
+    .landing-container .hero {
+        min-height: 100vh;
+        padding: var(--space-6) 0;
+    }
+
+    .landing-container .hero-content {
+        padding: 0 var(--space-6);
+        max-width: 700px;
+    }
+
+    .landing-container .hero .hero-title {
+        font-size: clamp(2rem, 5vw, 3rem) !important;
+        margin-bottom: var(--space-4) !important;
+        line-height: 1.15 !important;
+    }
+
+    .landing-container .hero-subtitle {
+        font-size: clamp(0.95rem, 2vw, 1.1rem);
+        margin-bottom: var(--space-8);
+        line-height: 1.5;
+    }
+
+    .landing-container .hero-cta {
+        flex-direction: row;
+        max-width: 100%;
+        gap: var(--space-3);
+    }
+
+    .landing-container .hero-cta button,
+    .landing-container .hero-cta a {
+        min-width: 160px;
+        max-width: 240px;
+        height: 44px;
+        font-size: 0.95rem;
+    }
+
+    /* Reduce orbit hole radius for better fit */
+    .landing-container .hero .hero-orbit-layer {
+        --orbit-hole-radius: clamp(12rem, 22vh, 18rem);
+    }
+}
+
+/* Very short height screens (< 580px) at desktop widths */
+@media (max-height: 580px) and (min-width: 1025px) {
+    .landing-container .hero-content {
+        max-width: 650px;
+    }
+
+    .landing-container .hero .hero-title {
+        font-size: clamp(1.75rem, 4.5vw, 2.5rem) !important;
+        margin-bottom: var(--space-3) !important;
+    }
+
+    .landing-container .hero-subtitle {
+        font-size: clamp(0.9rem, 1.8vw, 1rem);
+        margin-bottom: var(--space-6);
+    }
+
+    .landing-container .hero-cta button,
+    .landing-container .hero-cta a {
+        height: 40px;
+        font-size: 0.9rem;
     }
 }
 


### PR DESCRIPTION
- Add media queries for screens with max-height: 650px and 580px at desktop widths (1025px+)
- Optimize hero section layout for viewports like 1272x564
- Reduce padding and margins to fit content within limited vertical space
- Scale down typography (titles, subtitles) for better readability
- Adjust CTA button sizes and spacing for compact displays
- Optimize features section with reduced spacing and icon sizes
- Improve footer layout with compact padding for short screens

These changes ensure the landing page displays properly on small laptops and other devices with limited vertical space while maintaining desktop width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)