### PR TITLE
Rename Tech-Cal to Kure-Cal throughout codebase

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline Documentation
 
-This directory contains GitHub Actions workflows for the Tech Calendar project.
+This directory contains GitHub Actions workflows for the Kure-Cal project.
 
 ## 🚀 Workflows
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# KureCal (tech-cal)
+# Kure-Cal
 
-KureCal is a career operating system for discovering, planning, and acting on the tech events that move your professional goals forward.  
+Kure-Cal is a career operating system for discovering, planning, and acting on the tech events that move your professional goals forward.  
 We combine high-quality curation, adaptive scoring, intelligent scheduling, and longitudinal analytics to help teams and individual contributors focus on the events that matter.
 
 ---
 
 ## Table of Contents
 
-- [KureCal (tech-cal)](#kurecal-tech-cal)
+- [Kure-Cal](#kure-cal)
   - [Table of Contents](#table-of-contents)
   - [Product Overview](#product-overview)
   - [Feature Highlights](#feature-highlights)

--- a/src/app/(protected)/hackathons/layout.tsx
+++ b/src/app/(protected)/hackathons/layout.tsx
@@ -2,11 +2,11 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Hackathons - TechCal',
+  title: 'Hackathons - Kure-Cal',
   description: 'Discover and participate in exciting hackathons. Find teams, register for events, and showcase your coding skills.',
   keywords: ['hackathons', 'coding competitions', 'tech events', 'programming contests', 'developers'],
   openGraph: {
-    title: 'Hackathons - TechCal',
+    title: 'Hackathons - Kure-Cal',
     description: 'Discover and participate in exciting hackathons. Find teams, register for events, and showcase your coding skills.',
     type: 'website',
   },

--- a/src/app/(protected)/hackathons/page.tsx
+++ b/src/app/(protected)/hackathons/page.tsx
@@ -5,7 +5,7 @@ import { ProfileService } from '@/services/profileService';
 import HackathonClientView from '@/app/hackathons/HackathonClientView';
 
 export const metadata = {
-  title: 'Hackathons - TechCal',
+  title: 'Hackathons - Kure-Cal',
   description: 'Discover and participate in exciting hackathons. Find teams, register for events, and showcase your coding skills.',
 };
 

--- a/src/components/landing/ChaosToOrderSection.tsx
+++ b/src/components/landing/ChaosToOrderSection.tsx
@@ -158,7 +158,7 @@ export function ChaosToOrderSection() {
 
                     <div className="event-list-label" style={{ opacity: 0 }}>
                         <h3>Upcoming Events</h3>
-                        <p>Your personalized tech calendar</p>
+                        <p>Your personalized Kure calendar</p>
                     </div>
 
                     {animationEventsData.map((event, index) => (

--- a/src/services/googleCalendarService.ts
+++ b/src/services/googleCalendarService.ts
@@ -125,7 +125,7 @@ export class GoogleCalendarService {
 
             const eventDescription = event.description + 
                 (event.sourceUrl ? `\n\nEvent Details: ${event.sourceUrl}` : '') +
-                '\n\n📅 Added by TechCal';
+                '\n\n📅 Added by Kure-Cal';
 
             const response = await calendar.events.insert({
                 calendarId,
@@ -142,7 +142,7 @@ export class GoogleCalendarService {
                         timeZone: 'UTC'
                     },
                     source: {
-                        title: 'TechCal',
+                        title: 'Kure-Cal',
                         url: event.sourceUrl || 'https://kurecal.app'
                     }
                 }
@@ -181,9 +181,9 @@ export class GoogleCalendarService {
             
             const calendar = google.calendar({ version: 'v3', auth });
 
-            const eventDescription = event.description + 
+            const eventDescription = event.description +
                 (event.sourceUrl ? `\n\nEvent Details: ${event.sourceUrl}` : '') +
-                '\n\n📅 Added by TechCal';
+                '\n\n📅 Added by Kure-Cal';
 
             await calendar.events.update({
                 calendarId,
@@ -201,7 +201,7 @@ export class GoogleCalendarService {
                         timeZone: 'UTC'
                     },
                     source: {
-                        title: 'TechCal',
+                        title: 'Kure-Cal',
                         url: event.sourceUrl || 'https://kurecal.app'
                     }
                 }

--- a/src/utils/calendarUtils.ts
+++ b/src/utils/calendarUtils.ts
@@ -10,7 +10,7 @@ export function generateICS(event: Event, minutesBefore = 30): string {
   const end = event.endTime ? new Date(event.endTime) : new Date(start.getTime() + 60 * 60 * 1000);
   const dtStart = formatDateToICS(start);
   const dtEnd = formatDateToICS(end);
-  const uid = `${event.id}@tech-cal`;
+  const uid = `${event.id}@kure-cal`;
   const summary = (event.title || 'Event').replace(/\n/g, ' ');
   const description = (event.description || '').slice(0, 500).replace(/\n/g, ' ');
   const location = event.location || '';
@@ -21,7 +21,7 @@ export function generateICS(event: Event, minutesBefore = 30): string {
   return [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
-    'PRODID:-//tech-cal//dashboard//EN',
+    'PRODID:-//kure-cal//dashboard//EN',
     'CALSCALE:GREGORIAN',
     'BEGIN:VEVENT',
     `UID:${uid}`,


### PR DESCRIPTION
Update all user-facing references to use Kure-Cal branding:
- README and documentation
- Landing page copy
- Google Calendar integration labels
- Page metadata and titles
- ICS calendar file identifiers

Technical component names and CSS classes remain unchanged to maintain code stability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames user-facing “TechCal/Tech-Cal” references to “Kure-Cal” across docs, UI metadata/copy, Google Calendar integration, and ICS generation.
> 
> - **Branding Update**
>   - **Docs**: Rename project references to `Kure-Cal` in `.github/README.md` and `README.md` (headings, ToC).
>   - **Frontend**:
>     - Update page metadata titles in `src/app/(protected)/hackathons/layout.tsx` and `page.tsx`.
>     - Adjust landing copy in `src/components/landing/ChaosToOrderSection.tsx` ("Your personalized Kure calendar").
>   - **Integrations**: Change Google Calendar event footer and source title to `Kure-Cal` in `src/services/googleCalendarService.ts`.
>   - **Utilities**: Update ICS identifiers (`UID`, `PRODID`) to `kure-cal` in `src/utils/calendarUtils.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da92762131cace6f1fb9aa470a15fe16c501dd09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->