### PR TITLE
Update discover page route from /events to /discover

### DIFF
--- a/src/app/onboarding/career/page.tsx
+++ b/src/app/onboarding/career/page.tsx
@@ -81,7 +81,7 @@ function CareerOnboardingContent() {
     // Redirect if user has already completed onboarding
     React.useEffect(() => {
         if (!isLoading && hasCompletedOnboarding) {
-            router.push('/events');
+            router.push('/discover');
             return;
         }
     }, [hasCompletedOnboarding, isLoading, router]);
@@ -98,7 +98,7 @@ function CareerOnboardingContent() {
             await queryClient.invalidateQueries({ queryKey: ['userProfile'] });
             window.dispatchEvent(new CustomEvent('profile-updated'));
             showSuccess('Career profile completed! Discovering personalized events...');
-            router.push('/events');
+            router.push('/discover');
         } catch (error) {
             console.error('Career onboarding error:', error);
             const errorMessage = error instanceof Error
@@ -150,7 +150,7 @@ function CareerOnboardingContent() {
         }
 
         showInfo('You can complete your career profile later in settings');
-        router.push('/events');
+        router.push('/discover');
     };
 
     if (isCreatingProfile || (isLoading && !profile)) {

--- a/src/components/common/MobileBottomNav.tsx
+++ b/src/components/common/MobileBottomNav.tsx
@@ -16,7 +16,7 @@ const MobileBottomNav = () => {
     const router = useRouter();
 
     const navItems: NavItem[] = [
-        { name: 'Discover', href: '/events', icon: Compass },
+        { name: 'Discover', href: '/discover', icon: Compass },
         { name: 'Calendar', href: '/calendar', icon: CalendarBlank },
         { name: 'Community', href: '/community', icon: UsersThree },
         { name: 'Dashboard', href: '/dashboard', icon: SquaresFour },

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -39,7 +39,7 @@ export class NavigationUtils {
      * Navigate to discover page
      */
     toDiscover() {
-        this.router.push('/events');
+        this.router.push('/discover');
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR updates all navigation routes pointing to the events page to use the new `/discover` route instead of `/events`. This appears to be a route consolidation or rename to better reflect the page's purpose.

## Key Changes
- **Career onboarding page**: Updated three redirect routes from `/events` to `/discover`:
  - Redirect when user has already completed onboarding
  - Redirect after successful career profile completion
  - Redirect when skipping career profile setup
- **Mobile bottom navigation**: Updated the "Discover" nav item href from `/events` to `/discover`
- **Navigation utility**: Updated the `toDiscover()` method to push `/discover` instead of `/events`

## Implementation Details
All changes are straightforward route updates with no logic modifications. The updates ensure consistent navigation across the application to the new `/discover` route endpoint.

https://claude.ai/code/session_01GiznNPvaSUGdBsBE1z7G6r