### PR TITLE
Hotfix blank production screen caused by strict CSP

### DIFF
--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildCsp } from './csp';
+
+function getDirectiveValue(csp: string, directive: string): string {
+    const match = csp.match(new RegExp(`${directive} ([^;]+)`));
+    return match?.[1] ?? '';
+}
+
+describe('buildCsp', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('defaults production to a static-safe policy', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+        vi.stubEnv('CSP_STAGE', '');
+
+        const csp = buildCsp({
+            frameAncestors: "'none'",
+            nonce: 'default-nonce',
+        });
+        const scriptSrc = getDirectiveValue(csp, 'script-src');
+
+        expect(scriptSrc).toContain("'self'");
+        expect(scriptSrc).toContain("'unsafe-inline'");
+        expect(scriptSrc).not.toContain("'strict-dynamic'");
+        expect(scriptSrc).not.toContain("'nonce-default-nonce'");
+    });
+
+    it('downgrades strict mode unless nonce propagation is explicitly enabled', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+        vi.stubEnv('CSP_STAGE', 'strict');
+
+        const csp = buildCsp({
+            frameAncestors: "'none'",
+            nonce: 'strict-nonce',
+        });
+        const scriptSrc = getDirectiveValue(csp, 'script-src');
+
+        expect(scriptSrc).toContain("'unsafe-inline'");
+        expect(scriptSrc).not.toContain("'strict-dynamic'");
+        expect(scriptSrc).not.toContain("'nonce-strict-nonce'");
+    });
+
+    it('emits a nonce-based strict policy only when explicitly enabled', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+        vi.stubEnv('CSP_STAGE', 'strict');
+        vi.stubEnv('CSP_STRICT_NONCE_MODE', 'true');
+
+        const csp = buildCsp({
+            frameAncestors: "'none'",
+            nonce: 'strict-nonce',
+        });
+        const scriptSrc = getDirectiveValue(csp, 'script-src');
+
+        expect(scriptSrc).toContain("'nonce-strict-nonce'");
+        expect(scriptSrc).toContain("'strict-dynamic'");
+        expect(scriptSrc).not.toContain("'unsafe-inline'");
+    });
+
+    it('allows unsafe-eval in non-production static-safe mode only', () => {
+        vi.stubEnv('NODE_ENV', 'development');
+        vi.stubEnv('CSP_STAGE', 'compat');
+
+        const csp = buildCsp({
+            frameAncestors: '*',
+            nonce: 'dev-nonce',
+        });
+        const scriptSrc = getDirectiveValue(csp, 'script-src');
+
+        expect(scriptSrc).toContain("'unsafe-inline'");
+        expect(scriptSrc).toContain("'unsafe-eval'");
+        expect(scriptSrc).not.toContain("'nonce-dev-nonce'");
+    });
+});

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -7,11 +7,34 @@ type CspOptions = {
     nonce: string;
 };
 
+type CspFlags = {
+    allowUnsafeInline: boolean;
+    allowUnsafeEval: boolean;
+    includeNonce: boolean;
+    includeStrictDynamic: boolean;
+};
+
+function isStrictNonceModeEnabled() {
+    return process.env.CSP_STRICT_NONCE_MODE === 'true';
+}
+
 function getCspStage(isProduction: boolean): CspStage {
-    const fallbackStage = isProduction ? 'strict' : 'balanced';
+    const fallbackStage = isProduction ? 'compat' : 'balanced';
     const configuredStage = (process.env.CSP_STAGE || fallbackStage).toLowerCase();
 
-    if (configuredStage === 'compat' || configuredStage === 'balanced' || configuredStage === 'strict') {
+    if (
+        configuredStage === 'compat' ||
+        configuredStage === 'balanced' ||
+        configuredStage === 'strict'
+    ) {
+        if (
+            isProduction &&
+            configuredStage === 'strict' &&
+            !isStrictNonceModeEnabled()
+        ) {
+            return 'compat';
+        }
+
         return configuredStage;
     }
 
@@ -20,28 +43,38 @@ function getCspStage(isProduction: boolean): CspStage {
 
 function getCspFlags(stage: CspStage, isProduction: boolean) {
     if (stage === 'strict') {
-        return { allowUnsafeInline: false, allowUnsafeEval: false };
-    }
-
-    if (stage === 'compat') {
-        return { allowUnsafeInline: true, allowUnsafeEval: true };
+        return {
+            allowUnsafeInline: false,
+            allowUnsafeEval: !isProduction,
+            includeNonce: true,
+            includeStrictDynamic: true,
+        } satisfies CspFlags;
     }
 
     return {
-        allowUnsafeInline: !isProduction,
+        // Public routes remain static-safe until strict nonce propagation is
+        // explicitly enabled for production.
+        allowUnsafeInline: true,
         allowUnsafeEval: !isProduction,
-    };
+        includeNonce: false,
+        includeStrictDynamic: false,
+    } satisfies CspFlags;
 }
 
 export function buildCsp({ frameAncestors, nonce }: CspOptions): string {
     const isProduction = process.env.NODE_ENV === 'production';
     const cspStage = getCspStage(isProduction);
-    const { allowUnsafeInline, allowUnsafeEval } = getCspFlags(cspStage, isProduction);
+    const {
+        allowUnsafeInline,
+        allowUnsafeEval,
+        includeNonce,
+        includeStrictDynamic,
+    } = getCspFlags(cspStage, isProduction);
 
     const scriptSrc = [
         "'self'",
-        `'nonce-${nonce}'`,
-        "'strict-dynamic'",
+        includeNonce ? `'nonce-${nonce}'` : null,
+        includeStrictDynamic ? "'strict-dynamic'" : null,
         allowUnsafeInline ? "'unsafe-inline'" : null,
         allowUnsafeEval ? "'unsafe-eval'" : null,
         'https://cdnjs.cloudflare.com',


### PR DESCRIPTION
## Root cause
Production is serving a strict nonce-based CSP, but the App Router shell does not propagate matching nonces to the framework scripts on static routes. Browsers are blocking every `_next/static` script, so the page never hydrates and stays blank.

## Fix
- default production CSP to a static-safe mode
- downgrade `CSP_STAGE=strict` unless `CSP_STRICT_NONCE_MODE=true` is explicitly set
- add regression coverage for the downgrade and explicit strict opt-in behavior

## Validation
- npm exec vitest run src/lib/security/csp.test.ts
- npm run build

## Immediate ops note
To restore production before this PR is merged, set `CSP_STAGE=compat` and redeploy.