### PR TITLE
Claude/sad easley b089a9

### DIFF
--- a/packages/domain/src/community.ts
+++ b/packages/domain/src/community.ts
@@ -527,6 +527,60 @@ export const mobileCommunityEventsSchema = z.object({
   popularWithMembers: z.array(mobileCommunityEventCardSchema),
 });
 
+export const mobileCommunityDiscoveryCardSchema = mobileCommunityCircleSchema.extend({
+  contextSignals: z.array(z.string()).optional(),
+  upcomingEventTitle: z.string().nullable().optional(),
+});
+
+export const mobileCommunityRecentActivitySchema = z.object({
+  id: z.string(),
+  circleSlug: z.string(),
+  circleName: z.string(),
+  kind: z.enum(['post', 'event', 'member']),
+  summary: z.string(),
+  createdAt: z.string(),
+});
+
+export const mobileCommunityDiscoverySchema = z.object({
+  header: mobileSurfaceHeaderSchema,
+  forYou: z.array(mobileCommunityDiscoveryCardSchema),
+  joined: z.array(mobileCommunityDiscoveryCardSchema),
+  explore: z.array(mobileCommunityDiscoveryCardSchema),
+  suggested: z.array(mobileCommunityDiscoveryCardSchema),
+  recentActivity: z.array(mobileCommunityRecentActivitySchema),
+});
+
+export const mobileCommunityPersonContextSchema = mobileCommunityCircleMemberSchema.extend({
+  contextLabel: z.string().nullable().optional(),
+  sharedEventId: z.string().nullable().optional(),
+  sharedEventTitle: z.string().nullable().optional(),
+});
+
+export const mobileCommunityPeopleSchema = z.object({
+  header: mobileSurfaceHeaderSchema,
+  circle: mobileCommunityCircleSchema,
+  peopleForYou: z.array(mobileCommunityPersonContextSchema),
+  activeMembers: z.array(mobileCommunityPersonContextSchema),
+  goingToNextEvent: z.array(mobileCommunityPersonContextSchema),
+  mutuals: z.array(mobileCommunityPersonContextSchema),
+  newMembers: z.array(mobileCommunityPersonContextSchema),
+});
+
+export const mobileCommunityEventCardSchema = mobileCommunityUpcomingEventSchema.extend({
+  attendingFromCircleCount: z.number().int().nonnegative().optional(),
+  rsvpState: z.enum(['none', 'saved', 'going']).optional(),
+  discussionCount: z.number().int().nonnegative().optional(),
+});
+
+export const mobileCommunityEventsSchema = z.object({
+  header: mobileSurfaceHeaderSchema,
+  circle: mobileCommunityCircleSchema,
+  nextUp: z.array(mobileCommunityEventCardSchema),
+  thisMonth: z.array(mobileCommunityEventCardSchema),
+  past: z.array(mobileCommunityEventCardSchema),
+  popularWithMembers: z.array(mobileCommunityEventCardSchema),
+});
+
 export const mobileCommunityCirclePageSchema = z.object({
   header: mobileSurfaceHeaderSchema,
   circle: mobileCommunityCircleSchema,

--- a/src/services/communityHubService.ts
+++ b/src/services/communityHubService.ts
@@ -43,6 +43,42 @@ export interface CommunityDiscoveryData {
   recentActivity: CommunityRecentActivity[];
 }
 
+export interface CommunityDiscoveryCard {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  memberCount: number;
+  membershipState: 'none' | 'following' | 'joined';
+  tagline: string | null;
+  coverImageUrl: string | null;
+  iconUrl: string | null;
+  theme: string | null;
+  topicTags: string[];
+  locationScope: string | null;
+  activeMemberCount30d: number;
+  upcomingEventCount: number;
+  contextSignals: string[];
+  upcomingEventTitle: string | null;
+}
+
+export interface CommunityRecentActivity {
+  id: string;
+  circleSlug: string;
+  circleName: string;
+  kind: 'post' | 'event' | 'member';
+  summary: string;
+  createdAt: string;
+}
+
+export interface CommunityDiscoveryData {
+  forYou: CommunityDiscoveryCard[];
+  joined: CommunityDiscoveryCard[];
+  explore: CommunityDiscoveryCard[];
+  suggested: CommunityDiscoveryCard[];
+  recentActivity: CommunityRecentActivity[];
+}
+
 // ── Row types for DB results ────────────────────────────────────
 
 interface FeedPostRow {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1958,6 +1958,79 @@ export type Database = {
           },
         ]
       }
+      event_networking_summary: {
+        Row: {
+          created_at: string
+          event_id: string
+          id: string
+          last_outreach_logged_at: string | null
+          linkedin_requests_sent: number | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_id: string
+          id?: string
+          last_outreach_logged_at?: string | null
+          linkedin_requests_sent?: number | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event_id?: string
+          id?: string
+          last_outreach_logged_at?: string | null
+          linkedin_requests_sent?: number | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_networking_summary_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_networking_summary_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events_detailed"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_networking_summary_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events_with_location"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_networking_summary_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_networking_summary_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "event_networking_summary_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       event_prerequisites: {
         Row: {
           event_id: string
@@ -4738,6 +4811,123 @@ export type Database = {
           {
             foreignKeyName: "user_interactions_simple_user_id_fkey"
             columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      user_networking_contacts: {
+        Row: {
+          confirmed_connected_at: string | null
+          created_at: string
+          id: string
+          linkedin_requested_at: string | null
+          source_event_id: string | null
+          target_kind: string
+          target_speaker_id: string | null
+          target_user_id: string | null
+          updated_at: string
+          viewer_user_id: string
+        }
+        Insert: {
+          confirmed_connected_at?: string | null
+          created_at?: string
+          id?: string
+          linkedin_requested_at?: string | null
+          source_event_id?: string | null
+          target_kind: string
+          target_speaker_id?: string | null
+          target_user_id?: string | null
+          updated_at?: string
+          viewer_user_id: string
+        }
+        Update: {
+          confirmed_connected_at?: string | null
+          created_at?: string
+          id?: string
+          linkedin_requested_at?: string | null
+          source_event_id?: string | null
+          target_kind?: string
+          target_speaker_id?: string | null
+          target_user_id?: string | null
+          updated_at?: string
+          viewer_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_networking_contacts_source_event_id_fkey"
+            columns: ["source_event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_source_event_id_fkey"
+            columns: ["source_event_id"]
+            isOneToOne: false
+            referencedRelation: "events_detailed"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_source_event_id_fkey"
+            columns: ["source_event_id"]
+            isOneToOne: false
+            referencedRelation: "events_with_location"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_target_speaker_id_fkey"
+            columns: ["target_speaker_id"]
+            isOneToOne: false
+            referencedRelation: "event_speakers_flat"
+            referencedColumns: ["speaker_id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_target_speaker_id_fkey"
+            columns: ["target_speaker_id"]
+            isOneToOne: false
+            referencedRelation: "speakers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_target_user_id_fkey"
+            columns: ["target_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_target_user_id_fkey"
+            columns: ["target_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_target_user_id_fkey"
+            columns: ["target_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_viewer_user_id_fkey"
+            columns: ["viewer_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_viewer_user_id_fkey"
+            columns: ["viewer_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "user_networking_contacts_viewer_user_id_fkey"
+            columns: ["viewer_user_id"]
             isOneToOne: false
             referencedRelation: "user_event_stats"
             referencedColumns: ["user_id"]


### PR DESCRIPTION
## Summary

Extends the Phase 1 community redesign with the gaps that surfaced during review and visual verification — the membership model, pinning, and event linkage that the original phase shipped half-wired.

- **Follow vs Join split.** `circle_members.membership_state` ∈ `following | joined | muted`. `CircleDiscussionService.getViewerContext` reads it and threads it through every payload. The mobile detail screen no longer collapses any membership row to "joined", so followers don't see the post composer or other join-only UI. `isJoined` stays on the contract (derived) for in-flight clients.
- **Pinned posts.** New `POST /api/mobile/community/circles/[slug]/pin` (body `{ postId: uuid | null }`), `CommunityMutationsService.setPinnedPost`, server-side hoist of the pinned post to position 0 with `isPinned: true`, mobile pin/unpin button gated on a new `isModerator` flag.
- **Structured posts.** `communityPostDraftSchema` accepts optional `postType` + `eventId`. Mobile composer shows a chip row to pick (update / question / intro / event note); web composer unchanged.
- **Event linkage end-to-end.** `CommunityEventsService` and `CommunityPeopleService` read `circle_event_links` for the Events tab and the People tab's "Going to next event" section.
- **Active members signal.** Circle detail GET fires a fire-and-forget `last_visited_at` update for the viewer's `circle_members` row. New nightly `pg_cron` job (03:15 UTC) refreshes `circles.active_member_count_30d` via a set-based UPDATE — added in `supabase/migrations/20260507_active_member_count_cron.sql`.
- **Stale-tab fix.** Pull-to-refresh on the community detail screen now clears cached People / Events payloads so the visible tab refetches.
- **Cleanup.** Removed orphaned `loadMobileCommunityHome` helper; regenerated `src/types/supabase.ts`; stripped `as never` casts no longer needed.

## Database state

`20260505_community_redesign.sql` is already applied on production. This PR only adds the cron migration. Seed backfill (taglines, topic_tags, owner_id, 54 event links) was applied directly via Supabase MCP earlier and is already live.
