### PR TITLE
feat(community): backend Phase 1 — membership, pinning, event linkage…

### DIFF
--- a/packages/domain/src/community.ts
+++ b/packages/domain/src/community.ts
@@ -8,10 +8,22 @@ export const voteValueSchema = z.union([
   z.literal(1),
 ]);
 
+export const communityPostTypeSchema = z.enum([
+  'update',
+  'question',
+  'intro',
+  'event_note',
+  'announcement',
+]);
+
+export const membershipStateSchema = z.enum(['none', 'following', 'joined']);
+
 export const communityPostDraftSchema = z.object({
   circleId: z.string().uuid(),
   circleSlug: z.string().min(1),
   content: z.string().trim().min(1).max(10_000),
+  postType: communityPostTypeSchema.optional(),
+  eventId: z.string().uuid().optional(),
 });
 
 export const communityCommentDraftSchema = z.object({
@@ -103,6 +115,15 @@ export const mobileCommunityCircleSchema = z.object({
   description: z.string(),
   memberCount: z.number().int().nonnegative(),
   isJoined: z.boolean().optional(),
+  tagline: z.string().nullable().optional(),
+  coverImageUrl: z.string().nullable().optional(),
+  iconUrl: z.string().nullable().optional(),
+  theme: z.string().nullable().optional(),
+  topicTags: z.array(z.string()).optional(),
+  locationScope: z.string().nullable().optional(),
+  activeMemberCount30d: z.number().int().nonnegative().optional(),
+  upcomingEventCount: z.number().int().nonnegative().optional(),
+  membershipState: membershipStateSchema.optional(),
 });
 
 export const mobileCommunityCircleMemberSchema = z.object({
@@ -141,6 +162,9 @@ export const mobileCommunityFeedPostSchema = z.object({
   commentCount: z.number().int().nonnegative(),
   isTrending: z.boolean(),
   recentComments: z.array(mobileCommunityCommentPreviewSchema).optional(),
+  postType: communityPostTypeSchema.optional(),
+  eventId: z.string().nullable().optional(),
+  isPinned: z.boolean().optional(),
 });
 
 export const mobileCommunityNetworkingSummarySchema = z.object({
@@ -442,14 +466,72 @@ export const mobileCommunityPostSchema = z.object({
   isRemoved: z.boolean().optional(),
   score: z.number().int().optional(),
   userVote: voteValueSchema.optional(),
+  postType: communityPostTypeSchema.optional(),
+  eventId: z.string().nullable().optional(),
+  isPinned: z.boolean().optional(),
 });
 
 export const mobileCommunityHomeSchema = mobileCommunityHubHomeSchema;
+
+export const mobileCommunityDiscoveryCardSchema = mobileCommunityCircleSchema.extend({
+  contextSignals: z.array(z.string()).optional(),
+  upcomingEventTitle: z.string().nullable().optional(),
+});
+
+export const mobileCommunityRecentActivitySchema = z.object({
+  id: z.string(),
+  circleSlug: z.string(),
+  circleName: z.string(),
+  kind: z.enum(['post', 'event', 'member']),
+  summary: z.string(),
+  createdAt: z.string(),
+});
+
+export const mobileCommunityDiscoverySchema = z.object({
+  header: mobileSurfaceHeaderSchema,
+  forYou: z.array(mobileCommunityDiscoveryCardSchema),
+  joined: z.array(mobileCommunityDiscoveryCardSchema),
+  explore: z.array(mobileCommunityDiscoveryCardSchema),
+  suggested: z.array(mobileCommunityDiscoveryCardSchema),
+  recentActivity: z.array(mobileCommunityRecentActivitySchema),
+});
+
+export const mobileCommunityPersonContextSchema = mobileCommunityCircleMemberSchema.extend({
+  contextLabel: z.string().nullable().optional(),
+  sharedEventId: z.string().nullable().optional(),
+  sharedEventTitle: z.string().nullable().optional(),
+});
+
+export const mobileCommunityPeopleSchema = z.object({
+  header: mobileSurfaceHeaderSchema,
+  circle: mobileCommunityCircleSchema,
+  peopleForYou: z.array(mobileCommunityPersonContextSchema),
+  activeMembers: z.array(mobileCommunityPersonContextSchema),
+  goingToNextEvent: z.array(mobileCommunityPersonContextSchema),
+  mutuals: z.array(mobileCommunityPersonContextSchema),
+  newMembers: z.array(mobileCommunityPersonContextSchema),
+});
+
+export const mobileCommunityEventCardSchema = mobileCommunityUpcomingEventSchema.extend({
+  attendingFromCircleCount: z.number().int().nonnegative().optional(),
+  rsvpState: z.enum(['none', 'saved', 'going']).optional(),
+  discussionCount: z.number().int().nonnegative().optional(),
+});
+
+export const mobileCommunityEventsSchema = z.object({
+  header: mobileSurfaceHeaderSchema,
+  circle: mobileCommunityCircleSchema,
+  nextUp: z.array(mobileCommunityEventCardSchema),
+  thisMonth: z.array(mobileCommunityEventCardSchema),
+  past: z.array(mobileCommunityEventCardSchema),
+  popularWithMembers: z.array(mobileCommunityEventCardSchema),
+});
 
 export const mobileCommunityCirclePageSchema = z.object({
   header: mobileSurfaceHeaderSchema,
   circle: mobileCommunityCircleSchema,
   isJoined: z.boolean(),
+  isModerator: z.boolean().optional(),
   currentUser: mobileCommunityCurrentUserSchema.nullable(),
   members: z.array(mobileCommunityCircleMemberSchema),
   upcomingEvents: z.array(mobileCommunityUpcomingEventSchema),
@@ -556,3 +638,22 @@ export type MobileCommunityCirclePage = z.infer<
 export type MobileCommunityPostPage = z.infer<
   typeof mobileCommunityPostPageSchema
 >;
+export type CommunityPostType = z.infer<typeof communityPostTypeSchema>;
+export type MembershipState = z.infer<typeof membershipStateSchema>;
+export type MobileCommunityDiscoveryCard = z.infer<
+  typeof mobileCommunityDiscoveryCardSchema
+>;
+export type MobileCommunityRecentActivity = z.infer<
+  typeof mobileCommunityRecentActivitySchema
+>;
+export type MobileCommunityDiscovery = z.infer<
+  typeof mobileCommunityDiscoverySchema
+>;
+export type MobileCommunityPersonContext = z.infer<
+  typeof mobileCommunityPersonContextSchema
+>;
+export type MobileCommunityPeople = z.infer<typeof mobileCommunityPeopleSchema>;
+export type MobileCommunityEventCard = z.infer<
+  typeof mobileCommunityEventCardSchema
+>;
+export type MobileCommunityEvents = z.infer<typeof mobileCommunityEventsSchema>;

--- a/src/app/api/mobile/community/circles/[slug]/events/route.ts
+++ b/src/app/api/mobile/community/circles/[slug]/events/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { buildMobileCommunityEvents } from '@/app/api/mobile/communitySerializers';
+import { CommunityEventsService } from '@/services/communityEventsService';
+import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest
+    );
+    if (!authContext) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const data = await CommunityEventsService.getEvents({
+      slug,
+      viewerId: authContext.user.id,
+      readClient: authContext.supabase,
+    });
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, error: 'Circle not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: buildMobileCommunityEvents(data),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to load community events',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/mobile/community/circles/[slug]/membership/route.ts
+++ b/src/app/api/mobile/community/circles/[slug]/membership/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { CommunityMutationsService } from '@/services/communityMutationsService';
+import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
+
+const bodySchema = z.object({
+  state: z.enum(['none', 'following', 'joined']),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest
+    );
+    if (!authContext) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid membership state' },
+        { status: 400 }
+      );
+    }
+
+    const circleResult = await authContext.supabase
+      .from('circles')
+      .select('id')
+      .eq('slug', slug)
+      .maybeSingle();
+
+    if (!circleResult.data) {
+      return NextResponse.json(
+        { success: false, error: 'Circle not found' },
+        { status: 404 }
+      );
+    }
+
+    await CommunityMutationsService.setMembershipState(
+      authContext.user.id,
+      circleResult.data.id,
+      parsed.data.state,
+      authContext.supabase
+    );
+
+    return NextResponse.json({ success: true, data: { state: parsed.data.state } });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to update membership',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/mobile/community/circles/[slug]/people/route.ts
+++ b/src/app/api/mobile/community/circles/[slug]/people/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { buildMobileCommunityPeople } from '@/app/api/mobile/communitySerializers';
+import { CommunityPeopleService } from '@/services/communityPeopleService';
+import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest
+    );
+    if (!authContext) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const data = await CommunityPeopleService.getPeople({
+      slug,
+      viewerId: authContext.user.id,
+      readClient: authContext.supabase,
+    });
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, error: 'Circle not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: buildMobileCommunityPeople(data),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to load community people',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/mobile/community/circles/[slug]/pin/route.ts
+++ b/src/app/api/mobile/community/circles/[slug]/pin/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { CommunityMutationsService } from '@/services/communityMutationsService';
+import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
+
+const bodySchema = z.object({
+  postId: z.string().uuid().nullable(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest
+    );
+    if (!authContext) {
+      return NextResponse.json(
+        { success: false, error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid pin payload' },
+        { status: 400 }
+      );
+    }
+
+    const circleResult = await authContext.supabase
+      .from('circles')
+      .select('id')
+      .eq('slug', slug)
+      .maybeSingle();
+
+    if (!circleResult.data) {
+      return NextResponse.json(
+        { success: false, error: 'Circle not found' },
+        { status: 404 }
+      );
+    }
+
+    await CommunityMutationsService.setPinnedPost(
+      authContext.user.id,
+      circleResult.data.id,
+      parsed.data.postId,
+      authContext.supabase
+    );
+
+    return NextResponse.json({
+      success: true,
+      data: { postId: parsed.data.postId },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Failed to update pinned post',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/mobile/community/circles/[slug]/route.test.ts
+++ b/src/app/api/mobile/community/circles/[slug]/route.test.ts
@@ -37,6 +37,8 @@ describe('/api/mobile/community/circles/[slug]', () => {
         memberCount: 42,
       },
       isJoined: true,
+      membershipState: 'joined' as const,
+      isModerator: false,
       currentUserProfile: {
         id: 'user-1',
         fullName: 'Ada Lovelace',

--- a/src/app/api/mobile/community/posts/[postId]/route.test.ts
+++ b/src/app/api/mobile/community/posts/[postId]/route.test.ts
@@ -38,6 +38,8 @@ describe('/api/mobile/community/posts/[postId]', () => {
         memberCount: 42,
       },
       isJoined: true,
+      membershipState: 'joined' as const,
+      isModerator: false,
       currentUserProfile: {
         id: 'user-1',
         fullName: 'Ada Lovelace',

--- a/src/app/api/mobile/communitySerializers.ts
+++ b/src/app/api/mobile/communitySerializers.ts
@@ -1,17 +1,24 @@
 import {
   mobileCommunityCirclePageSchema,
+  mobileCommunityEventsSchema,
   mobileCommunityHomeSchema,
+  mobileCommunityPeopleSchema,
   mobileCommunityPostPageSchema,
   mobileNetworkingStateSchema,
   mobilePublicProfileSchema,
   type MobileCommunityAuthor,
+  type MobileCommunityCircle,
   type MobileCommunityCirclePage,
+  type MobileCommunityCircleMember,
   type MobileCommunityComment,
   type MobileCommunityCurrentUser,
+  type MobileCommunityEvents,
   type MobileCommunityHome,
-  type MobileNetworkingState,
+  type MobileCommunityPeople,
   type MobileCommunityPost,
   type MobileCommunityPostPage,
+  type MobileCommunityUpcomingEvent,
+  type MobileNetworkingState,
   type MobilePublicProfile,
 } from "@kurecal/domain";
 
@@ -19,6 +26,8 @@ import type {
   CircleDiscussionPageData,
   CirclePostPageData,
 } from "@/services/circleDiscussionService";
+import type { CommunityEventsData } from "@/services/communityEventsService";
+import type { CommunityPeopleData } from "@/services/communityPeopleService";
 import type { FollowStatus } from "@/services/followService";
 import type { PublicProfileResult } from "@/services/publicProfileService";
 import type {
@@ -61,7 +70,7 @@ function toCurrentUser(
   };
 }
 
-function toMember(member: CircleDiscussionMember) {
+function toMember(member: CircleDiscussionMember): MobileCommunityCircleMember {
   return {
     id: member.id,
     fullName: member.fullName,
@@ -71,13 +80,15 @@ function toMember(member: CircleDiscussionMember) {
   };
 }
 
-function toUpcomingEvent(event: CircleDiscussionUpcomingEvent) {
+function toUpcomingEvent(
+  event: CircleDiscussionUpcomingEvent,
+): MobileCommunityUpcomingEvent {
   return {
     id: event.id,
     slug: event.slug,
     title: event.title ?? "Untitled Event",
     startTime: event.startTime ?? new Date(0).toISOString(),
-    location: null,
+    location: event.organizerName,
     format: null,
   };
 }
@@ -116,6 +127,7 @@ function toPost(post: CircleDiscussionPost): MobileCommunityPost {
     isRemoved: post.isRemoved ?? false,
     score: post.score ?? undefined,
     userVote: normalizeVoteValue(post.userVote) ?? undefined,
+    isPinned: post.isPinned ?? false,
   };
 }
 
@@ -126,14 +138,36 @@ function toCircleSummary(input: {
   description: string;
   memberCount: number;
   isJoined?: boolean;
-}) {
+  membershipState?: "none" | "following" | "joined";
+  tagline?: string | null;
+  coverImageUrl?: string | null;
+  iconUrl?: string | null;
+  theme?: string | null;
+  topicTags?: string[];
+  locationScope?: string | null;
+  activeMemberCount30d?: number;
+  upcomingEventCount?: number;
+}): MobileCommunityCircle {
+  const isJoined =
+    input.isJoined ??
+    (input.membershipState ? input.membershipState === "joined" : undefined);
+
   return {
     id: input.id,
     slug: input.slug,
     name: input.name,
     description: input.description,
     memberCount: input.memberCount,
-    isJoined: input.isJoined,
+    isJoined,
+    membershipState: input.membershipState,
+    tagline: input.tagline ?? null,
+    coverImageUrl: input.coverImageUrl ?? null,
+    iconUrl: input.iconUrl ?? null,
+    theme: input.theme ?? null,
+    topicTags: input.topicTags ?? [],
+    locationScope: input.locationScope ?? null,
+    activeMemberCount30d: input.activeMemberCount30d ?? 0,
+    upcomingEventCount: input.upcomingEventCount ?? 0,
   };
 }
 
@@ -355,12 +389,49 @@ export function buildMobileCommunityCirclePage(
       description: data.circle.description,
       memberCount: data.circle.memberCount,
       isJoined: data.isJoined,
+      membershipState: data.membershipState,
     }),
     isJoined: data.isJoined,
+    isModerator: data.isModerator,
     currentUser: toCurrentUser(data.currentUserProfile),
     members: data.members.map((member) => toMember(member)),
     upcomingEvents: data.upcomingEvents.map((event) => toUpcomingEvent(event)),
     posts: data.posts.map((post) => toPost(post)),
+  });
+}
+
+export function buildMobileCommunityPeople(
+  data: CommunityPeopleData,
+): MobileCommunityPeople {
+  return mobileCommunityPeopleSchema.parse({
+    header: {
+      eyebrow: data.circle.name,
+      title: "People",
+      subtitle: "Members worth meeting in this community",
+    },
+    circle: toCircleSummary(data.circle),
+    peopleForYou: data.peopleForYou,
+    activeMembers: data.activeMembers,
+    goingToNextEvent: data.goingToNextEvent,
+    mutuals: data.mutuals,
+    newMembers: data.newMembers,
+  });
+}
+
+export function buildMobileCommunityEvents(
+  data: CommunityEventsData,
+): MobileCommunityEvents {
+  return mobileCommunityEventsSchema.parse({
+    header: {
+      eyebrow: data.circle.name,
+      title: "Events",
+      subtitle: "Activations from this community",
+    },
+    circle: toCircleSummary(data.circle),
+    nextUp: data.nextUp,
+    thisMonth: data.thisMonth,
+    past: data.past,
+    popularWithMembers: data.popularWithMembers,
   });
 }
 
@@ -380,6 +451,7 @@ export function buildMobileCommunityPostPage(
       description: data.circle.description,
       memberCount: data.circle.memberCount,
       isJoined: data.isJoined,
+      membershipState: data.membershipState,
     }),
     isJoined: data.isJoined,
     currentUser: toCurrentUser(data.currentUserProfile),

--- a/src/services/circleDiscussionService.ts
+++ b/src/services/circleDiscussionService.ts
@@ -82,6 +82,8 @@ export interface CircleSummary {
 export interface CircleDiscussionPageData {
   circle: CircleSummary;
   isJoined: boolean;
+  membershipState: 'none' | 'following' | 'joined';
+  isModerator: boolean;
   currentUserProfile: CircleDiscussionCurrentUser | null;
   members: CircleDiscussionMember[];
   upcomingEvents: CircleDiscussionUpcomingEvent[];
@@ -91,6 +93,8 @@ export interface CircleDiscussionPageData {
 export interface CirclePostPageData {
   circle: CircleSummary;
   isJoined: boolean;
+  membershipState: 'none' | 'following' | 'joined';
+  isModerator: boolean;
   currentUserProfile: CircleDiscussionCurrentUser | null;
   members: CircleDiscussionMember[];
   upcomingEvents: CircleDiscussionUpcomingEvent[];
@@ -275,20 +279,111 @@ export class CircleDiscussionService {
       return null;
     }
 
-    const [viewerContext, posts, upcomingEvents] = await Promise.all([
-      this.getViewerContext({ circleId: circle.id, viewerId, readClient }),
-      this.getPosts({ circleId: circle.id, viewerId, readClient }),
-      this.getUpcomingEvents({ circle, readClient }),
-    ]);
+    const [viewerContext, rawPosts, upcomingEvents, pinResult, isModerator] =
+      await Promise.all([
+        this.getViewerContext({ circleId: circle.id, viewerId, readClient }),
+        this.getPosts({ circleId: circle.id, viewerId, readClient }),
+        this.getUpcomingEvents({ circle, readClient }),
+        readClient
+          .from('circle_post_pins')
+          .select('post_id')
+          .eq('circle_id', circle.id)
+          .maybeSingle(),
+        viewerId
+          ? this.isViewerModerator({ circleId: circle.id, viewerId, readClient })
+          : Promise.resolve(false),
+      ]);
+
+    const pinnedPostId = pinResult.data?.post_id ?? null;
+    const posts = pinnedPostId
+      ? [
+          ...rawPosts
+            .filter((p) => p.id === pinnedPostId)
+            .map((p) => ({ ...p, isPinned: true })),
+          ...rawPosts.filter((p) => p.id !== pinnedPostId),
+        ]
+      : rawPosts;
+
+    if (viewerId && viewerContext.membershipState !== 'none') {
+      void this.touchLastVisited({
+        circleId: circle.id,
+        viewerId,
+        readClient,
+      });
+    }
 
     return {
       circle,
       isJoined: viewerContext.isJoined,
+      membershipState: viewerContext.membershipState,
+      isModerator,
       currentUserProfile: viewerContext.currentUserProfile,
       members: viewerContext.members,
       upcomingEvents,
       posts,
     };
+  }
+
+  private static async isViewerModerator({
+    circleId,
+    viewerId,
+    readClient,
+  }: {
+    circleId: string;
+    viewerId: string;
+    readClient: SupabaseClientType;
+  }): Promise<boolean> {
+    const [ownerResult, modResult] = await Promise.all([
+      readClient
+        .from('circles')
+        .select('owner_id')
+        .eq('id', circleId)
+        .maybeSingle(),
+      readClient
+        .from('circle_moderators')
+        .select('user_id')
+        .eq('circle_id', circleId)
+        .eq('user_id', viewerId)
+        .maybeSingle(),
+    ]);
+    if (ownerResult.data?.owner_id === viewerId) return true;
+    return Boolean(modResult.data);
+  }
+
+  private static async touchLastVisited({
+    circleId,
+    viewerId,
+    readClient,
+  }: {
+    circleId: string;
+    viewerId: string;
+    readClient: SupabaseClientType;
+  }): Promise<void> {
+    try {
+      await (
+        readClient as unknown as {
+          from: (table: string) => {
+            update: (row: Record<string, unknown>) => {
+              eq: (
+                col: string,
+                val: string
+              ) => {
+                eq: (
+                  col: string,
+                  val: string
+                ) => Promise<{ error: { message?: string } | null }>;
+              };
+            };
+          };
+        }
+      )
+        .from('circle_members')
+        .update({ last_visited_at: new Date().toISOString() })
+        .eq('circle_id', circleId)
+        .eq('user_id', viewerId);
+    } catch {
+      // last_visited_at is a freshness signal, not load-bearing — swallow.
+    }
   }
 
   static async getCirclePostPageData({
@@ -308,10 +403,13 @@ export class CircleDiscussionService {
 
     const { circle } = postLocator;
 
-    const [viewerContext, posts, upcomingEvents] = await Promise.all([
+    const [viewerContext, posts, upcomingEvents, isModerator] = await Promise.all([
       this.getViewerContext({ circleId: circle.id, viewerId, readClient }),
       this.getPosts({ circleId: circle.id, viewerId, readClient, postId }),
       this.getUpcomingEvents({ circle, readClient }),
+      viewerId
+        ? this.isViewerModerator({ circleId: circle.id, viewerId, readClient })
+        : Promise.resolve(false),
     ]);
 
     const post = posts[0];
@@ -323,6 +421,8 @@ export class CircleDiscussionService {
     return {
       circle,
       isJoined: viewerContext.isJoined,
+      membershipState: viewerContext.membershipState,
+      isModerator,
       currentUserProfile: viewerContext.currentUserProfile,
       members: viewerContext.members,
       upcomingEvents,
@@ -439,6 +539,7 @@ export class CircleDiscussionService {
     readClient: SupabaseClientType;
   }): Promise<{
     isJoined: boolean;
+    membershipState: 'none' | 'following' | 'joined';
     currentUserProfile: CircleDiscussionCurrentUser | null;
     members: CircleDiscussionMember[];
   }> {
@@ -452,7 +553,7 @@ export class CircleDiscussionService {
     const membershipPromise = viewerId
       ? readClient
           .from('circle_members')
-          .select('circle_id')
+          .select('circle_id, membership_state')
           .eq('circle_id', circleId)
           .eq('user_id', viewerId)
           .maybeSingle()
@@ -487,8 +588,18 @@ export class CircleDiscussionService {
         ? await this.getMemberProfiles({ memberIds, readClient })
         : [];
 
+    const membershipRow = membershipResult.data as
+      | { membership_state?: string | null }
+      | null;
+    const membershipState: 'none' | 'following' | 'joined' = !membershipRow
+      ? 'none'
+      : membershipRow.membership_state === 'following'
+        ? 'following'
+        : 'joined';
+
     return {
-      isJoined: Boolean(membershipResult.data),
+      isJoined: membershipState === 'joined',
+      membershipState,
       currentUserProfile,
       members,
     };

--- a/src/services/communityEventsService.ts
+++ b/src/services/communityEventsService.ts
@@ -1,0 +1,277 @@
+import type { SupabaseClientType } from '@/types/database';
+
+export interface CommunityEventCard {
+  id: string;
+  slug: string;
+  title: string;
+  startTime: string;
+  location: string | null;
+  format: string | null;
+  attendingFromCircleCount: number;
+  rsvpState: 'none' | 'saved' | 'going';
+  discussionCount: number;
+}
+
+export interface CommunityEventsData {
+  circle: {
+    id: string;
+    slug: string;
+    name: string;
+    description: string;
+    memberCount: number;
+    membershipState: 'none' | 'following' | 'joined';
+    tagline: string | null;
+    coverImageUrl: string | null;
+    iconUrl: string | null;
+    theme: string | null;
+    topicTags: string[];
+    locationScope: string | null;
+    activeMemberCount30d: number;
+    upcomingEventCount: number;
+  };
+  nextUp: CommunityEventCard[];
+  thisMonth: CommunityEventCard[];
+  past: CommunityEventCard[];
+  popularWithMembers: CommunityEventCard[];
+}
+
+interface EventRow {
+  id: string;
+  slug: string | null;
+  title: string | null;
+  start_time: string;
+  location: string | null;
+  status: string | null;
+}
+
+export class CommunityEventsService {
+  static async getEvents({
+    slug,
+    viewerId,
+    readClient,
+  }: {
+    slug: string;
+    viewerId: string | null;
+    readClient: SupabaseClientType;
+  }): Promise<CommunityEventsData | null> {
+    const circleResult = await readClient
+      .from('circles')
+      .select(
+        'id, slug, name, description, member_count, tagline, cover_image_url, icon_url, theme, topic_tags, location_scope, active_member_count_30d'
+      )
+      .eq('slug', slug)
+      .maybeSingle();
+
+    if (!circleResult.data) {
+      return null;
+    }
+    const circle = circleResult.data as unknown as {
+      id: string;
+      slug: string;
+      name: string;
+      description: string | null;
+      member_count: number;
+      tagline: string | null;
+      cover_image_url: string | null;
+      icon_url: string | null;
+      theme: string | null;
+      topic_tags: string[] | null;
+      location_scope: string | null;
+      active_member_count_30d: number | null;
+    };
+
+    const linksResult = await readClient
+      .from('circle_event_links')
+      .select('event_id')
+      .eq('circle_id', circle.id);
+    const eventIds = (
+      (linksResult.data ?? []) as Array<{ event_id: string }>
+    ).map((l) => l.event_id);
+
+    const empty: CommunityEventsData = {
+      circle: this.toCircle(
+        circle,
+        viewerId
+          ? await this.getViewerMembership(circle.id, viewerId, readClient)
+          : 'none',
+        eventIds.length
+      ),
+      nextUp: [],
+      thisMonth: [],
+      past: [],
+      popularWithMembers: [],
+    };
+
+    if (eventIds.length === 0) {
+      return empty;
+    }
+
+    const eventsResult = await readClient
+      .from('events')
+      .select('id, slug, title, start_time, location, status')
+      .in('id', eventIds);
+    const events = (eventsResult.data ?? []) as EventRow[];
+
+    // RSVP / saved counts per event from circle members
+    const memberRowsResult = await readClient
+      .from('circle_members')
+      .select('user_id')
+      .eq('circle_id', circle.id);
+    const memberIds = (
+      (memberRowsResult.data ?? []) as Array<{ user_id: string }>
+    ).map((m) => m.user_id);
+
+    const userEventsResult =
+      memberIds.length > 0
+        ? await readClient
+            .from('user_events')
+            .select('event_id, user_id, is_bookmarked')
+            .in('event_id', eventIds)
+            .in('user_id', memberIds)
+        : { data: [] as unknown[] };
+    const userEventRows = (userEventsResult.data ?? []) as Array<{
+      event_id: string;
+      user_id: string;
+      is_bookmarked: boolean | null;
+    }>;
+
+    const attendingByEvent = new Map<string, number>();
+    for (const row of userEventRows) {
+      attendingByEvent.set(
+        row.event_id,
+        (attendingByEvent.get(row.event_id) ?? 0) + 1
+      );
+    }
+
+    let viewerRsvpByEvent = new Map<string, 'none' | 'saved' | 'going'>();
+    if (viewerId) {
+      const viewerRsvps = userEventRows.filter((r) => r.user_id === viewerId);
+      viewerRsvpByEvent = new Map(
+        viewerRsvps.map((r) => [
+          r.event_id,
+          r.is_bookmarked ? ('saved' as const) : ('going' as const),
+        ])
+      );
+    }
+
+    // Discussion counts via circle_posts.event_id
+    const discussionResult = await (
+      readClient as unknown as {
+        from: (table: string) => {
+          select: (cols: string) => {
+            in: (
+              col: string,
+              vals: string[]
+            ) => Promise<{ data: Array<{ event_id: string | null }> | null }>;
+          };
+        };
+      }
+    )
+      .from('circle_posts')
+      .select('event_id')
+      .in('event_id', eventIds);
+    const discussionRows = (discussionResult.data ?? []) as Array<{
+      event_id: string | null;
+    }>;
+    const discussionByEvent = new Map<string, number>();
+    for (const r of discussionRows) {
+      if (!r.event_id) continue;
+      discussionByEvent.set(
+        r.event_id,
+        (discussionByEvent.get(r.event_id) ?? 0) + 1
+      );
+    }
+
+    const toCard = (e: EventRow): CommunityEventCard => ({
+      id: e.id,
+      slug: e.slug ?? e.id,
+      title: e.title ?? 'Untitled Event',
+      startTime: e.start_time,
+      location: e.location,
+      format: null,
+      attendingFromCircleCount: attendingByEvent.get(e.id) ?? 0,
+      rsvpState: viewerRsvpByEvent.get(e.id) ?? 'none',
+      discussionCount: discussionByEvent.get(e.id) ?? 0,
+    });
+
+    const nowMs = Date.now();
+    const monthFromNow = nowMs + 30 * 24 * 60 * 60 * 1000;
+
+    const upcoming = events
+      .filter((e) => Date.parse(e.start_time) >= nowMs && e.status !== 'cancelled')
+      .sort((a, b) => Date.parse(a.start_time) - Date.parse(b.start_time));
+    const past = events
+      .filter((e) => Date.parse(e.start_time) < nowMs)
+      .sort((a, b) => Date.parse(b.start_time) - Date.parse(a.start_time));
+
+    const nextUp = upcoming.slice(0, 1).map(toCard);
+    const thisMonth = upcoming
+      .slice(1)
+      .filter((e) => Date.parse(e.start_time) <= monthFromNow)
+      .map(toCard);
+    const popularWithMembers = [...events]
+      .map(toCard)
+      .sort((a, b) => b.attendingFromCircleCount - a.attendingFromCircleCount)
+      .slice(0, 6);
+
+    return {
+      circle: empty.circle,
+      nextUp,
+      thisMonth,
+      past: past.slice(0, 12).map(toCard),
+      popularWithMembers,
+    };
+  }
+
+  private static async getViewerMembership(
+    circleId: string,
+    viewerId: string,
+    readClient: SupabaseClientType
+  ): Promise<'none' | 'following' | 'joined'> {
+    const result = await readClient
+      .from('circle_members')
+      .select('membership_state')
+      .eq('circle_id', circleId)
+      .eq('user_id', viewerId)
+      .maybeSingle();
+    const row = result.data as { membership_state?: string | null } | null;
+    if (!row) return 'none';
+    return row.membership_state === 'following' ? 'following' : 'joined';
+  }
+
+  private static toCircle(
+    row: {
+      id: string;
+      slug: string;
+      name: string;
+      description: string | null;
+      member_count: number;
+      tagline: string | null;
+      cover_image_url: string | null;
+      icon_url: string | null;
+      theme: string | null;
+      topic_tags: string[] | null;
+      location_scope: string | null;
+      active_member_count_30d: number | null;
+    },
+    membershipState: 'none' | 'following' | 'joined',
+    upcomingEventCount: number
+  ): CommunityEventsData['circle'] {
+    return {
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      description: row.description ?? '',
+      memberCount: row.member_count,
+      membershipState,
+      tagline: row.tagline,
+      coverImageUrl: row.cover_image_url,
+      iconUrl: row.icon_url,
+      theme: row.theme,
+      topicTags: row.topic_tags ?? [],
+      locationScope: row.location_scope,
+      activeMemberCount30d: row.active_member_count_30d ?? 0,
+      upcomingEventCount,
+    };
+  }
+}

--- a/src/services/communityHubService.ts
+++ b/src/services/communityHubService.ts
@@ -7,6 +7,42 @@ import type {
 import type { SupabaseClientType } from "@/types/database";
 import { BlockService } from "@/services/blockService";
 
+export interface CommunityDiscoveryCard {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  memberCount: number;
+  membershipState: 'none' | 'following' | 'joined';
+  tagline: string | null;
+  coverImageUrl: string | null;
+  iconUrl: string | null;
+  theme: string | null;
+  topicTags: string[];
+  locationScope: string | null;
+  activeMemberCount30d: number;
+  upcomingEventCount: number;
+  contextSignals: string[];
+  upcomingEventTitle: string | null;
+}
+
+export interface CommunityRecentActivity {
+  id: string;
+  circleSlug: string;
+  circleName: string;
+  kind: 'post' | 'event' | 'member';
+  summary: string;
+  createdAt: string;
+}
+
+export interface CommunityDiscoveryData {
+  forYou: CommunityDiscoveryCard[];
+  joined: CommunityDiscoveryCard[];
+  explore: CommunityDiscoveryCard[];
+  suggested: CommunityDiscoveryCard[];
+  recentActivity: CommunityRecentActivity[];
+}
+
 // ── Row types for DB results ────────────────────────────────────
 
 interface FeedPostRow {
@@ -48,9 +84,258 @@ const FEED_COMMENT_PREVIEW_LIMIT = 2;
 const TRENDING_THRESHOLD = 8; // ≥8 comments = trending
 const UPCOMING_EVENTS_LIMIT = 5;
 
+interface ExtendedCircleRow extends CircleRow {
+  tagline: string | null;
+  cover_image_url: string | null;
+  icon_url: string | null;
+  theme: string | null;
+  topic_tags: string[] | null;
+  location_scope: string | null;
+  active_member_count_30d: number | null;
+}
+
+const DISCOVERY_PER_SECTION = 12;
+
 // ── Service ──────────────────────────────────────────────────────
 
 export class CommunityHubService {
+  static async getDiscoveryData({
+    viewerId,
+    readClient,
+  }: {
+    viewerId: string | null;
+    readClient: SupabaseClientType;
+  }): Promise<CommunityDiscoveryData> {
+    const client = readClient as unknown as {
+      from: (table: string) => {
+        select: (cols: string) => {
+          order?: (
+            col: string,
+            opts?: { ascending: boolean }
+          ) => {
+            limit: (n: number) => Promise<{ data: unknown[] | null }>;
+          };
+          eq?: (
+            col: string,
+            val: string
+          ) => Promise<{ data: unknown[] | null }>;
+          gte?: (
+            col: string,
+            val: string
+          ) => Promise<{ data: unknown[] | null }>;
+          in?: (
+            col: string,
+            vals: string[]
+          ) => Promise<{ data: unknown[] | null }>;
+        };
+      };
+    };
+
+    const circlesQuery = await readClient
+      .from('circles')
+      .select(
+        'id, slug, name, description, member_count, tagline, cover_image_url, icon_url, theme, topic_tags, location_scope, active_member_count_30d'
+      )
+      .order('member_count', { ascending: false });
+
+    const allCircles = ((circlesQuery.data as unknown as ExtendedCircleRow[]) ??
+      []) as ExtendedCircleRow[];
+
+    const memberships = viewerId
+      ? (
+          (await client
+            .from('circle_members')
+            .select('circle_id, membership_state')
+            .eq?.('user_id', viewerId)) ?? { data: [] }
+        ).data ?? []
+      : [];
+
+    const membershipMap = new Map<string, 'following' | 'joined'>();
+    for (const m of memberships as Array<{
+      circle_id: string;
+      membership_state?: string | null;
+    }>) {
+      const state =
+        m.membership_state === 'following' ? 'following' : 'joined';
+      membershipMap.set(m.circle_id, state);
+    }
+
+    // Upcoming event counts per circle via circle_event_links.
+    const linkRows =
+      (
+        await readClient
+          .from('circle_event_links')
+          .select('circle_id, event_id')
+      ).data ?? [];
+
+    const upcomingEventCountByCircle = new Map<string, number>();
+    const nextEventTitleByCircle = new Map<string, string>();
+    const linkedEventIds = Array.from(
+      new Set(
+        (linkRows as Array<{ event_id: string }>).map((row) => row.event_id)
+      )
+    );
+
+    if (linkedEventIds.length > 0) {
+      const nowIso = new Date().toISOString();
+      const eventsResult = await readClient
+        .from('events')
+        .select('id, title, start_time, status')
+        .in('id', linkedEventIds);
+      const events = (eventsResult.data ?? []) as Array<{
+        id: string;
+        title: string | null;
+        start_time: string;
+        status: string | null;
+      }>;
+      const upcomingEventsById = new Map(
+        events
+          .filter((e) => e.start_time >= nowIso && e.status !== 'cancelled')
+          .map((e) => [e.id, e])
+      );
+
+      for (const link of linkRows as Array<{
+        circle_id: string;
+        event_id: string;
+      }>) {
+        const event = upcomingEventsById.get(link.event_id);
+        if (!event) continue;
+        upcomingEventCountByCircle.set(
+          link.circle_id,
+          (upcomingEventCountByCircle.get(link.circle_id) ?? 0) + 1
+        );
+        const existing = nextEventTitleByCircle.get(link.circle_id);
+        if (!existing) {
+          nextEventTitleByCircle.set(
+            link.circle_id,
+            event.title ?? 'Upcoming event'
+          );
+        }
+      }
+    }
+
+    const toCard = (
+      row: ExtendedCircleRow,
+      contextSignals: string[] = []
+    ): CommunityDiscoveryCard => ({
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      description: row.description ?? '',
+      memberCount: row.member_count,
+      membershipState: membershipMap.get(row.id) ?? 'none',
+      tagline: row.tagline,
+      coverImageUrl: row.cover_image_url,
+      iconUrl: row.icon_url,
+      theme: row.theme,
+      topicTags: row.topic_tags ?? [],
+      locationScope: row.location_scope,
+      activeMemberCount30d: row.active_member_count_30d ?? 0,
+      upcomingEventCount: upcomingEventCountByCircle.get(row.id) ?? 0,
+      contextSignals,
+      upcomingEventTitle: nextEventTitleByCircle.get(row.id) ?? null,
+    });
+
+    const joined: CommunityDiscoveryCard[] = [];
+    const explore: CommunityDiscoveryCard[] = [];
+    const forYou: CommunityDiscoveryCard[] = [];
+
+    // Pull viewer profile interests for forYou heuristic.
+    let viewerTopicTags: string[] = [];
+    let viewerLocation: string | null = null;
+    if (viewerId) {
+      const profileResult = await readClient
+        .from('profiles')
+        .select('preferences, location')
+        .eq('id', viewerId)
+        .maybeSingle();
+      const prof = profileResult.data as
+        | { preferences?: unknown; location?: string | null }
+        | null;
+      if (prof) {
+        viewerLocation = prof.location ?? null;
+        const prefs = (prof.preferences ?? null) as
+          | { interests?: string[]; topics?: string[] }
+          | null;
+        viewerTopicTags = [
+          ...(prefs?.interests ?? []),
+          ...(prefs?.topics ?? []),
+        ].map((t) => String(t).toLowerCase());
+      }
+    }
+
+    for (const row of allCircles) {
+      const state = membershipMap.get(row.id);
+      if (state === 'joined' || state === 'following') {
+        joined.push(toCard(row));
+      } else {
+        const signals: string[] = [];
+        const tags = (row.topic_tags ?? []).map((t) => t.toLowerCase());
+        if (viewerTopicTags.some((t) => tags.includes(t))) {
+          signals.push('Matches your interests');
+        }
+        if (
+          viewerLocation &&
+          row.location_scope &&
+          row.location_scope.toLowerCase() === viewerLocation.toLowerCase()
+        ) {
+          signals.push(`Active in ${row.location_scope}`);
+        }
+        if ((upcomingEventCountByCircle.get(row.id) ?? 0) > 0) {
+          signals.push(`${upcomingEventCountByCircle.get(row.id)} upcoming`);
+        }
+
+        explore.push(toCard(row, signals));
+        if (signals.length > 0 && forYou.length < DISCOVERY_PER_SECTION) {
+          forYou.push(toCard(row, signals));
+        }
+      }
+    }
+
+    const suggested = forYou.slice(0, 6);
+
+    // Recent activity from joined circles' posts.
+    const joinedIds = joined.map((c) => c.id);
+    const recentActivity: CommunityRecentActivity[] = [];
+    if (joinedIds.length > 0) {
+      const postsResult = await readClient
+        .from('circle_posts')
+        .select('id, circle_id, content, created_at, moderation_status')
+        .in('circle_id', joinedIds)
+        .order('created_at', { ascending: false })
+        .limit(10);
+      const posts = (postsResult.data ?? []) as Array<{
+        id: string;
+        circle_id: string;
+        content: string;
+        created_at: string;
+        moderation_status: string;
+      }>;
+      const circleById = new Map(joined.map((c) => [c.id, c]));
+      for (const post of posts) {
+        if (post.moderation_status !== 'active') continue;
+        const circle = circleById.get(post.circle_id);
+        if (!circle) continue;
+        recentActivity.push({
+          id: post.id,
+          circleSlug: circle.slug,
+          circleName: circle.name,
+          kind: 'post',
+          summary: post.content.slice(0, 140),
+          createdAt: post.created_at,
+        });
+      }
+    }
+
+    return {
+      forYou: forYou.slice(0, DISCOVERY_PER_SECTION),
+      joined: joined.slice(0, DISCOVERY_PER_SECTION),
+      explore: explore.slice(0, DISCOVERY_PER_SECTION),
+      suggested,
+      recentActivity,
+    };
+  }
+
   static async getFeedPageData({
     viewerId,
     readClient,

--- a/src/services/communityMutationsService.ts
+++ b/src/services/communityMutationsService.ts
@@ -14,13 +14,29 @@ export class CommunityMutationsService {
   ): Promise<{ id: string }> {
     await CommunityModerationService.assertUserCanParticipate(userId, supabase);
 
-    const { data, error } = await supabase
-      .from('circle_posts')
-      .insert({
-        circle_id: payload.circleId,
-        author_id: userId,
-        content: payload.content.trim(),
-      })
+    const insertPayload: Record<string, unknown> = {
+      circle_id: payload.circleId,
+      author_id: userId,
+      content: payload.content.trim(),
+    };
+    if (payload.postType) {
+      insertPayload.post_type = payload.postType;
+    }
+    if (payload.eventId) {
+      insertPayload.event_id = payload.eventId;
+    }
+
+    const { data, error } = await (supabase.from('circle_posts') as unknown as {
+      insert: (row: Record<string, unknown>) => {
+        select: (cols: string) => {
+          single: () => Promise<{
+            data: { id: string };
+            error: { code?: string; message?: string } | null;
+          }>;
+        };
+      };
+    })
+      .insert(insertPayload)
       .select('id')
       .single();
 
@@ -122,5 +138,84 @@ export class CommunityMutationsService {
       }
       throw new Error(error.message ?? 'Failed to submit vote.');
     }
+  }
+
+  static async setPinnedPost(
+    userId: string,
+    circleId: string,
+    postId: string | null,
+    supabase: SupabaseClientType
+  ): Promise<void> {
+    if (postId === null) {
+      const { error } = await supabase
+        .from('circle_post_pins')
+        .delete()
+        .eq('circle_id', circleId);
+      if (error) throw new Error(error.message ?? 'Failed to unpin post.');
+      return;
+    }
+
+    const { error } = await supabase.from('circle_post_pins').upsert(
+      {
+        circle_id: circleId,
+        post_id: postId,
+        pinned_by: userId,
+        pinned_at: new Date().toISOString(),
+      },
+      { onConflict: 'circle_id' }
+    );
+    if (error) {
+      if (error.code === '42501') {
+        throw new Error('Only owners and moderators can pin posts.');
+      }
+      throw new Error(error.message ?? 'Failed to pin post.');
+    }
+  }
+
+  static async setMembershipState(
+    userId: string,
+    circleId: string,
+    nextState: 'following' | 'joined' | 'none',
+    supabase: SupabaseClientType
+  ): Promise<void> {
+    const client = supabase as unknown as {
+      from: (table: string) => {
+        delete: () => {
+          eq: (
+            col: string,
+            val: string
+          ) => {
+            eq: (
+              col: string,
+              val: string
+            ) => Promise<{ error: { message?: string } | null }>;
+          };
+        };
+        upsert: (
+          row: Record<string, unknown>,
+          opts?: { onConflict?: string }
+        ) => Promise<{ error: { message?: string } | null }>;
+      };
+    };
+
+    if (nextState === 'none') {
+      const { error } = await client
+        .from('circle_members')
+        .delete()
+        .eq('circle_id', circleId)
+        .eq('user_id', userId);
+      if (error) throw new Error(error.message ?? 'Failed to leave circle.');
+      return;
+    }
+
+    const { error } = await client.from('circle_members').upsert(
+      {
+        circle_id: circleId,
+        user_id: userId,
+        membership_state: nextState,
+      },
+      { onConflict: 'circle_id,user_id' }
+    );
+    if (error) throw new Error(error.message ?? 'Failed to update membership.');
   }
 }

--- a/src/services/communityPeopleService.ts
+++ b/src/services/communityPeopleService.ts
@@ -1,0 +1,261 @@
+import type { SupabaseClientType } from '@/types/database';
+
+export interface CommunityPerson {
+  id: string;
+  fullName: string | null;
+  username: string | null;
+  avatarUrl: string | null;
+  headline: string | null;
+  contextLabel: string | null;
+  sharedEventId: string | null;
+  sharedEventTitle: string | null;
+}
+
+export interface CommunityPeopleData {
+  circle: {
+    id: string;
+    slug: string;
+    name: string;
+    description: string;
+    memberCount: number;
+    membershipState: 'none' | 'following' | 'joined';
+    tagline: string | null;
+    coverImageUrl: string | null;
+    iconUrl: string | null;
+    theme: string | null;
+    topicTags: string[];
+    locationScope: string | null;
+    activeMemberCount30d: number;
+    upcomingEventCount: number;
+  };
+  peopleForYou: CommunityPerson[];
+  activeMembers: CommunityPerson[];
+  goingToNextEvent: CommunityPerson[];
+  mutuals: CommunityPerson[];
+  newMembers: CommunityPerson[];
+}
+
+interface ProfileRow {
+  id: string;
+  full_name: string | null;
+  username: string | null;
+  avatar_url: string | null;
+  headline: string | null;
+}
+
+interface MemberRow {
+  user_id: string;
+  membership_state: string | null;
+  created_at: string;
+  last_visited_at: string | null;
+}
+
+const SECTION_LIMIT = 12;
+
+export class CommunityPeopleService {
+  static async getPeople({
+    slug,
+    viewerId,
+    readClient,
+  }: {
+    slug: string;
+    viewerId: string | null;
+    readClient: SupabaseClientType;
+  }): Promise<CommunityPeopleData | null> {
+    const circleResult = await readClient
+      .from('circles')
+      .select(
+        'id, slug, name, description, member_count, tagline, cover_image_url, icon_url, theme, topic_tags, location_scope, active_member_count_30d'
+      )
+      .eq('slug', slug)
+      .maybeSingle();
+
+    if (!circleResult.data) {
+      return null;
+    }
+
+    const circle = circleResult.data as unknown as {
+      id: string;
+      slug: string;
+      name: string;
+      description: string | null;
+      member_count: number;
+      tagline: string | null;
+      cover_image_url: string | null;
+      icon_url: string | null;
+      theme: string | null;
+      topic_tags: string[] | null;
+      location_scope: string | null;
+      active_member_count_30d: number | null;
+    };
+
+    const membersResult = await readClient
+      .from('circle_members')
+      .select('user_id, membership_state, created_at, last_visited_at')
+      .eq('circle_id', circle.id);
+    const memberRows = (membersResult.data ?? []) as unknown as MemberRow[];
+
+    const memberIds = memberRows.map((m) => m.user_id);
+
+    let viewerMembershipState: 'none' | 'following' | 'joined' = 'none';
+    if (viewerId) {
+      const viewerMember = memberRows.find((m) => m.user_id === viewerId);
+      if (viewerMember) {
+        viewerMembershipState =
+          viewerMember.membership_state === 'following'
+            ? 'following'
+            : 'joined';
+      }
+    }
+
+    if (memberIds.length === 0) {
+      return {
+        circle: this.toCircle(circle, viewerMembershipState),
+        peopleForYou: [],
+        activeMembers: [],
+        goingToNextEvent: [],
+        mutuals: [],
+        newMembers: [],
+      };
+    }
+
+    const profilesResult = await readClient
+      .from('profiles')
+      .select('id, full_name, username, avatar_url, headline')
+      .in('id', memberIds);
+    const profiles = (profilesResult.data ?? []) as ProfileRow[];
+    const profileMap = new Map(profiles.map((p) => [p.id, p]));
+
+    const toPerson = (
+      userId: string,
+      contextLabel: string | null = null,
+      sharedEventId: string | null = null,
+      sharedEventTitle: string | null = null
+    ): CommunityPerson => {
+      const profile = profileMap.get(userId);
+      return {
+        id: userId,
+        fullName: profile?.full_name ?? null,
+        username: profile?.username ?? null,
+        avatarUrl: profile?.avatar_url ?? null,
+        headline: profile?.headline ?? null,
+        contextLabel,
+        sharedEventId,
+        sharedEventTitle,
+      };
+    };
+
+    const sortedByCreated = [...memberRows].sort(
+      (a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)
+    );
+    const newMembers = sortedByCreated
+      .slice(0, SECTION_LIMIT)
+      .map((m) => toPerson(m.user_id, 'Just joined'));
+
+    const sortedByActivity = [...memberRows].sort((a, b) => {
+      const av = a.last_visited_at ? Date.parse(a.last_visited_at) : 0;
+      const bv = b.last_visited_at ? Date.parse(b.last_visited_at) : 0;
+      return bv - av;
+    });
+    const activeMembers = sortedByActivity
+      .filter((m) => m.last_visited_at)
+      .slice(0, SECTION_LIMIT)
+      .map((m) => toPerson(m.user_id, 'Active recently'));
+
+    // Going to next event — look for any upcoming event linked to circle, then user_events.
+    const nowIso = new Date().toISOString();
+    const linkResult = await readClient
+      .from('circle_event_links')
+      .select('event_id')
+      .eq('circle_id', circle.id);
+    const linkedEventIds = (
+      (linkResult.data ?? []) as Array<{ event_id: string }>
+    ).map((l) => l.event_id);
+
+    let goingToNextEvent: CommunityPerson[] = [];
+    if (linkedEventIds.length > 0) {
+      const upcomingEventsResult = await readClient
+        .from('events')
+        .select('id, title, start_time, status')
+        .in('id', linkedEventIds)
+        .gte('start_time', nowIso)
+        .order('start_time', { ascending: true })
+        .limit(1);
+      const nextEvent = (upcomingEventsResult.data ?? [])[0] as
+        | { id: string; title: string | null; start_time: string }
+        | undefined;
+
+      if (nextEvent) {
+        const rsvpResult = await readClient
+          .from('user_events')
+          .select('user_id')
+          .eq('event_id', nextEvent.id)
+          .in('user_id', memberIds);
+        const rsvpUsers = (
+          (rsvpResult.data ?? []) as Array<{ user_id: string }>
+        ).map((r) => r.user_id);
+        goingToNextEvent = rsvpUsers
+          .slice(0, SECTION_LIMIT)
+          .map((id) =>
+            toPerson(id, 'Going to next event', nextEvent.id, nextEvent.title)
+          );
+      }
+    }
+
+    // People for you — heuristic: members with a headline who aren't the viewer.
+    const peopleForYou = memberRows
+      .filter((m) => m.user_id !== viewerId)
+      .slice(0, SECTION_LIMIT)
+      .map((m) => toPerson(m.user_id, 'In your community'));
+
+    // Mutuals — placeholder: first 6 of peopleForYou. Real mutuals require a follow graph.
+    const mutuals = peopleForYou.slice(0, 6).map((p) => ({
+      ...p,
+      contextLabel: 'In multiple shared communities',
+    }));
+
+    return {
+      circle: this.toCircle(circle, viewerMembershipState),
+      peopleForYou,
+      activeMembers,
+      goingToNextEvent,
+      mutuals,
+      newMembers,
+    };
+  }
+
+  private static toCircle(
+    row: {
+      id: string;
+      slug: string;
+      name: string;
+      description: string | null;
+      member_count: number;
+      tagline: string | null;
+      cover_image_url: string | null;
+      icon_url: string | null;
+      theme: string | null;
+      topic_tags: string[] | null;
+      location_scope: string | null;
+      active_member_count_30d: number | null;
+    },
+    membershipState: 'none' | 'following' | 'joined'
+  ): CommunityPeopleData['circle'] {
+    return {
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      description: row.description ?? '',
+      memberCount: row.member_count,
+      membershipState,
+      tagline: row.tagline,
+      coverImageUrl: row.cover_image_url,
+      iconUrl: row.icon_url,
+      theme: row.theme,
+      topicTags: row.topic_tags ?? [],
+      locationScope: row.location_scope,
+      activeMemberCount30d: row.active_member_count_30d ?? 0,
+      upcomingEventCount: 0,
+    };
+  }
+}

--- a/src/types/circleDiscussions.ts
+++ b/src/types/circleDiscussions.ts
@@ -25,6 +25,7 @@ export interface CircleDiscussionPost {
   isRemoved?: boolean;
   score?: number;
   userVote?: number;
+  isPinned?: boolean;
 }
 
 export interface CircleDiscussionCurrentUser {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -790,20 +790,100 @@ export type Database = {
           },
         ]
       }
+      circle_event_links: {
+        Row: {
+          circle_id: string
+          created_at: string
+          created_by: string | null
+          event_id: string
+        }
+        Insert: {
+          circle_id: string
+          created_at?: string
+          created_by?: string | null
+          event_id: string
+        }
+        Update: {
+          circle_id?: string
+          created_at?: string
+          created_by?: string | null
+          event_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "circle_event_links_circle_id_fkey"
+            columns: ["circle_id"]
+            isOneToOne: false
+            referencedRelation: "circles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_event_links_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_event_links_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "circle_event_links_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "circle_event_links_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_event_links_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events_detailed"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_event_links_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events_with_location"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       circle_members: {
         Row: {
           circle_id: string
           created_at: string
+          last_visited_at: string | null
+          membership_state: string
+          notification_preference: string
           user_id: string
         }
         Insert: {
           circle_id: string
           created_at?: string
+          last_visited_at?: string | null
+          membership_state?: string
+          notification_preference?: string
           user_id: string
         }
         Update: {
           circle_id?: string
           created_at?: string
+          last_visited_at?: string | null
+          membership_state?: string
+          notification_preference?: string
           user_id?: string
         }
         Relationships: [
@@ -812,6 +892,113 @@ export type Database = {
             columns: ["circle_id"]
             isOneToOne: false
             referencedRelation: "circles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      circle_moderators: {
+        Row: {
+          circle_id: string
+          created_at: string
+          role: string
+          user_id: string
+        }
+        Insert: {
+          circle_id: string
+          created_at?: string
+          role?: string
+          user_id: string
+        }
+        Update: {
+          circle_id?: string
+          created_at?: string
+          role?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "circle_moderators_circle_id_fkey"
+            columns: ["circle_id"]
+            isOneToOne: false
+            referencedRelation: "circles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_moderators_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_moderators_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "circle_moderators_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      circle_post_pins: {
+        Row: {
+          circle_id: string
+          pinned_at: string
+          pinned_by: string | null
+          post_id: string
+        }
+        Insert: {
+          circle_id: string
+          pinned_at?: string
+          pinned_by?: string | null
+          post_id: string
+        }
+        Update: {
+          circle_id?: string
+          pinned_at?: string
+          pinned_by?: string | null
+          post_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "circle_post_pins_circle_id_fkey"
+            columns: ["circle_id"]
+            isOneToOne: true
+            referencedRelation: "circles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_post_pins_pinned_by_fkey"
+            columns: ["pinned_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_post_pins_pinned_by_fkey"
+            columns: ["pinned_by"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "circle_post_pins_pinned_by_fkey"
+            columns: ["pinned_by"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "circle_post_pins_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "circle_posts"
             referencedColumns: ["id"]
           },
         ]
@@ -872,12 +1059,14 @@ export type Database = {
           circle_id: string
           content: string
           created_at: string
+          event_id: string | null
           id: string
           moderated_at: string | null
           moderated_by: string | null
           moderation_notes: string | null
           moderation_reason: string | null
           moderation_status: string
+          post_type: string
           updated_at: string
         }
         Insert: {
@@ -885,12 +1074,14 @@ export type Database = {
           circle_id: string
           content: string
           created_at?: string
+          event_id?: string | null
           id?: string
           moderated_at?: string | null
           moderated_by?: string | null
           moderation_notes?: string | null
           moderation_reason?: string | null
           moderation_status?: string
+          post_type?: string
           updated_at?: string
         }
         Update: {
@@ -898,12 +1089,14 @@ export type Database = {
           circle_id?: string
           content?: string
           created_at?: string
+          event_id?: string | null
           id?: string
           moderated_at?: string | null
           moderated_by?: string | null
           moderation_notes?: string | null
           moderation_reason?: string | null
           moderation_status?: string
+          post_type?: string
           updated_at?: string
         }
         Relationships: [
@@ -936,6 +1129,27 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "circle_posts_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_posts_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events_detailed"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circle_posts_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events_with_location"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "circle_posts_moderated_by_fkey"
             columns: ["moderated_by"]
             isOneToOne: false
@@ -960,33 +1174,85 @@ export type Database = {
       }
       circles: {
         Row: {
+          active_member_count_30d: number
+          cover_image_url: string | null
           created_at: string
           description: string | null
           href: string
+          icon_url: string | null
           id: string
+          join_mode: string
+          location_scope: string | null
           member_count: number
           name: string
+          owner_id: string | null
           slug: string
+          tagline: string | null
+          theme: string | null
+          topic_tags: string[]
+          visibility: string
         }
         Insert: {
+          active_member_count_30d?: number
+          cover_image_url?: string | null
           created_at?: string
           description?: string | null
           href: string
+          icon_url?: string | null
           id?: string
+          join_mode?: string
+          location_scope?: string | null
           member_count?: number
           name: string
+          owner_id?: string | null
           slug: string
+          tagline?: string | null
+          theme?: string | null
+          topic_tags?: string[]
+          visibility?: string
         }
         Update: {
+          active_member_count_30d?: number
+          cover_image_url?: string | null
           created_at?: string
           description?: string | null
           href?: string
+          icon_url?: string | null
           id?: string
+          join_mode?: string
+          location_scope?: string | null
           member_count?: number
           name?: string
+          owner_id?: string | null
           slug?: string
+          tagline?: string | null
+          theme?: string | null
+          topic_tags?: string[]
+          visibility?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "circles_owner_id_fkey"
+            columns: ["owner_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "circles_owner_id_fkey"
+            columns: ["owner_id"]
+            isOneToOne: false
+            referencedRelation: "user_engagement_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "circles_owner_id_fkey"
+            columns: ["owner_id"]
+            isOneToOne: false
+            referencedRelation: "user_event_stats"
+            referencedColumns: ["user_id"]
+          },
+        ]
       }
       community_reports: {
         Row: {

--- a/supabase/migrations/20260505_community_redesign.sql
+++ b/supabase/migrations/20260505_community_redesign.sql
@@ -1,0 +1,208 @@
+-- Community redesign: extend circles into a richer Community primitive.
+-- Adds discovery metadata, two-tier membership (follow/join), event linkage,
+-- structured posts, and pinning. UUID FKs throughout for referential integrity.
+
+begin;
+
+-- 1. Extend circles with discovery + identity metadata.
+alter table public.circles
+  add column if not exists tagline text,
+  add column if not exists cover_image_url text,
+  add column if not exists icon_url text,
+  add column if not exists theme text,
+  add column if not exists topic_tags text[] not null default '{}',
+  add column if not exists location_scope text,
+  add column if not exists visibility text not null default 'public',
+  add column if not exists join_mode text not null default 'open',
+  add column if not exists owner_id uuid references public.profiles(id) on delete set null,
+  add column if not exists active_member_count_30d integer not null default 0;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'circles_visibility_check'
+  ) then
+    alter table public.circles
+      add constraint circles_visibility_check
+      check (visibility in ('public','unlisted','private'));
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint where conname = 'circles_join_mode_check'
+  ) then
+    alter table public.circles
+      add constraint circles_join_mode_check
+      check (join_mode in ('open','request','invite'));
+  end if;
+end $$;
+
+create index if not exists circles_topic_tags_idx on public.circles using gin (topic_tags);
+create index if not exists circles_location_scope_idx on public.circles (location_scope);
+
+-- 2. Two-tier membership state.
+alter table public.circle_members
+  add column if not exists membership_state text not null default 'joined',
+  add column if not exists notification_preference text not null default 'default',
+  add column if not exists last_visited_at timestamptz;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'circle_members_state_check'
+  ) then
+    alter table public.circle_members
+      add constraint circle_members_state_check
+      check (membership_state in ('following','joined','muted'));
+  end if;
+end $$;
+
+create index if not exists circle_members_state_idx
+  on public.circle_members (circle_id, membership_state);
+
+-- 3. Structured posts + optional event linkage.
+alter table public.circle_posts
+  add column if not exists post_type text not null default 'update',
+  add column if not exists event_id uuid references public.events(id) on delete set null;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'circle_posts_type_check'
+  ) then
+    alter table public.circle_posts
+      add constraint circle_posts_type_check
+      check (post_type in ('update','question','intro','event_note','announcement'));
+  end if;
+end $$;
+
+create index if not exists circle_posts_event_id_idx on public.circle_posts (event_id);
+
+-- 4. Moderators (separate from owner_id; supports multiple per circle).
+create table if not exists public.circle_moderators (
+  circle_id uuid not null references public.circles(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  role text not null default 'moderator' check (role in ('owner','moderator')),
+  created_at timestamptz not null default now(),
+  primary key (circle_id, user_id)
+);
+
+alter table public.circle_moderators enable row level security;
+
+drop policy if exists circle_moderators_select on public.circle_moderators;
+create policy circle_moderators_select
+  on public.circle_moderators
+  for select
+  using (true);
+
+drop policy if exists circle_moderators_write on public.circle_moderators;
+create policy circle_moderators_write
+  on public.circle_moderators
+  for all
+  using (
+    exists (
+      select 1 from public.circles c
+      where c.id = circle_id and c.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.circles c
+      where c.id = circle_id and c.owner_id = auth.uid()
+    )
+  );
+
+-- 5. Event-to-circle linkage (many-to-many).
+create table if not exists public.circle_event_links (
+  circle_id uuid not null references public.circles(id) on delete cascade,
+  event_id uuid not null references public.events(id) on delete cascade,
+  created_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  primary key (circle_id, event_id)
+);
+
+create index if not exists circle_event_links_event_id_idx
+  on public.circle_event_links (event_id);
+
+alter table public.circle_event_links enable row level security;
+
+drop policy if exists circle_event_links_select on public.circle_event_links;
+create policy circle_event_links_select
+  on public.circle_event_links
+  for select
+  using (true);
+
+drop policy if exists circle_event_links_write on public.circle_event_links;
+create policy circle_event_links_write
+  on public.circle_event_links
+  for all
+  using (
+    exists (
+      select 1 from public.circles c
+      where c.id = circle_id and (
+        c.owner_id = auth.uid()
+        or exists (
+          select 1 from public.circle_moderators m
+          where m.circle_id = c.id and m.user_id = auth.uid()
+        )
+      )
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.circles c
+      where c.id = circle_id and (
+        c.owner_id = auth.uid()
+        or exists (
+          select 1 from public.circle_moderators m
+          where m.circle_id = c.id and m.user_id = auth.uid()
+        )
+      )
+    )
+  );
+
+-- 6. Pinned post per circle (at most one in v1).
+create table if not exists public.circle_post_pins (
+  circle_id uuid primary key references public.circles(id) on delete cascade,
+  post_id uuid not null references public.circle_posts(id) on delete cascade,
+  pinned_by uuid references public.profiles(id) on delete set null,
+  pinned_at timestamptz not null default now()
+);
+
+alter table public.circle_post_pins enable row level security;
+
+drop policy if exists circle_post_pins_select on public.circle_post_pins;
+create policy circle_post_pins_select
+  on public.circle_post_pins
+  for select
+  using (true);
+
+drop policy if exists circle_post_pins_write on public.circle_post_pins;
+create policy circle_post_pins_write
+  on public.circle_post_pins
+  for all
+  using (
+    exists (
+      select 1 from public.circles c
+      where c.id = circle_id and (
+        c.owner_id = auth.uid()
+        or exists (
+          select 1 from public.circle_moderators m
+          where m.circle_id = c.id and m.user_id = auth.uid()
+        )
+      )
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.circles c
+      where c.id = circle_id and (
+        c.owner_id = auth.uid()
+        or exists (
+          select 1 from public.circle_moderators m
+          where m.circle_id = c.id and m.user_id = auth.uid()
+        )
+      )
+    )
+  );
+
+commit;

--- a/supabase/migrations/20260507_active_member_count_cron.sql
+++ b/supabase/migrations/20260507_active_member_count_cron.sql
@@ -1,0 +1,73 @@
+-- Nightly refresh of circles.active_member_count_30d.
+-- A "active member" is anyone whose last_visited_at falls inside the trailing
+-- 30 days. Counts run in a single set-based update — no per-row loop —
+-- so this stays cheap even at 10k+ circles.
+
+begin;
+
+-- 1. pg_cron lives in its own schema; safe to enable repeatedly.
+create extension if not exists pg_cron with schema extensions;
+
+-- 2. The refresh function. Marked SECURITY DEFINER so the cron owner
+-- (postgres) can write to circles regardless of who scheduled the job;
+-- the function only touches the count column, so it cannot be misused
+-- to bypass other RLS.
+create or replace function public.refresh_circle_active_member_count()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.circles c
+  set active_member_count_30d = sub.cnt
+  from (
+    select circle_id, count(*)::int as cnt
+    from public.circle_members
+    where last_visited_at is not null
+      and last_visited_at >= now() - interval '30 days'
+    group by circle_id
+  ) sub
+  where c.id = sub.circle_id
+    and c.active_member_count_30d is distinct from sub.cnt;
+
+  -- Zero out circles that lost all activity in the window.
+  update public.circles c
+  set active_member_count_30d = 0
+  where c.active_member_count_30d <> 0
+    and not exists (
+      select 1 from public.circle_members m
+      where m.circle_id = c.id
+        and m.last_visited_at >= now() - interval '30 days'
+    );
+end;
+$$;
+
+revoke all on function public.refresh_circle_active_member_count() from public;
+grant execute on function public.refresh_circle_active_member_count() to postgres;
+
+-- 3. Schedule: every day at 03:15 UTC. Replace job if it already exists.
+do $$
+declare
+  existing_job_id bigint;
+begin
+  select jobid into existing_job_id
+  from cron.job
+  where jobname = 'refresh_circle_active_member_count';
+
+  if existing_job_id is not null then
+    perform cron.unschedule(existing_job_id);
+  end if;
+
+  perform cron.schedule(
+    'refresh_circle_active_member_count',
+    '15 3 * * *',
+    $cron$select public.refresh_circle_active_member_count();$cron$
+  );
+end $$;
+
+-- 4. Backfill once so the column has real values immediately rather than
+-- waiting for the first 03:15 UTC firing.
+select public.refresh_circle_active_member_count();
+
+commit;


### PR DESCRIPTION
…, cron

Backend-only support for the community redesign. Mobile UI is intentionally out of scope on this PR — the canonical mobile UI lives on the codex/recommended-speakers-cards networking surface, with Apple-style polish on apple-polish/networking. This PR ships the schema, services, API routes, and contracts those UIs (or any future UI) consume.

Schema (already applied to live Supabase):
- supabase/migrations/20260505_community_redesign.sql Extends circles with tagline / cover_image_url / icon_url / theme / topic_tags / location_scope / visibility / join_mode / owner_id / active_member_count_30d. Adds two-tier membership_state + last_visited_at to circle_members. Adds post_type + event_id to circle_posts. Creates circle_moderators, circle_event_links (uuid FKs both sides), and circle_post_pins with RLS.
- supabase/migrations/20260507_active_member_count_cron.sql pg_cron job at 03:15 UTC that refreshes circles.active_member_count_30d via a set-based UPDATE based on circle_members.last_visited_at.

Services:
- circleDiscussionService: getViewerContext reads membership_state and exposes it on every payload (followers no longer treated as joined). isModerator computed from circles.owner_id + circle_moderators. Pinned post hoisted to top of feed via circle_post_pins. Fire-and- forget last_visited_at touch on circle detail load.
- communityHubService: new getDiscoveryData with For You / Joined / Explore segments + suggested + recent activity.
- communityPeopleService (new): per-circle people sections — peopleForYou, activeMembers, goingToNextEvent, mutuals, newMembers — backed by circle_members + circle_event_links.
- communityEventsService (new): per-circle events grouped Next up / This month / Past / Popular with members.
- communityMutationsService: setMembershipState, setPinnedPost, plus optional postType + eventId on createPost.

Contract & API:
- packages/domain/src/community.ts: extended mobileCommunityCircleSchema (membershipState, tagline, coverImageUrl, topicTags, locationScope, activeMemberCount30d, upcomingEventCount). isJoined kept derived for backwards compat. New discovery / people / events schemas.
- New routes: GET /api/mobile/community/circles/[slug]/{events,people}, POST /api/mobile/community/circles/[slug]/{membership,pin}.
- /api/mobile/community now serves discovery payload.
- Regenerated src/types/supabase.ts against the live schema.