### PR TITLE
fix(csp): default production to compat and gate strict mode behind CS…

### DIFF
--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -44,9 +44,40 @@ describe('buildCsp', () => {
         expect(scriptSrc).not.toContain("'nonce-balanced-nonce'");
     });
 
-    it('emits a nonce-based strict policy in production', () => {
+    it('defaults production to a static-safe policy when CSP_STAGE is unset', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+        vi.stubEnv('CSP_STAGE', '');
+
+        const csp = buildCsp({
+            frameAncestors: "'none'",
+            nonce: 'default-nonce',
+        });
+        const scriptSrc = getDirectiveValue(csp, 'script-src');
+
+        expect(scriptSrc).toContain("'unsafe-inline'");
+        expect(scriptSrc).not.toContain("'strict-dynamic'");
+        expect(scriptSrc).not.toContain("'nonce-default-nonce'");
+    });
+
+    it('downgrades CSP_STAGE=strict to compat unless CSP_STRICT_NONCE_MODE is enabled', () => {
         vi.stubEnv('NODE_ENV', 'production');
         vi.stubEnv('CSP_STAGE', 'strict');
+
+        const csp = buildCsp({
+            frameAncestors: "'none'",
+            nonce: 'strict-nonce',
+        });
+        const scriptSrc = getDirectiveValue(csp, 'script-src');
+
+        expect(scriptSrc).toContain("'unsafe-inline'");
+        expect(scriptSrc).not.toContain("'strict-dynamic'");
+        expect(scriptSrc).not.toContain("'nonce-strict-nonce'");
+    });
+
+    it('emits a nonce-based strict policy only when CSP_STRICT_NONCE_MODE is enabled', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+        vi.stubEnv('CSP_STAGE', 'strict');
+        vi.stubEnv('CSP_STRICT_NONCE_MODE', 'true');
 
         const csp = buildCsp({
             frameAncestors: "'none'",

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -14,11 +14,18 @@ type CspFlags = {
     includeStrictDynamic: boolean;
 };
 
+function isStrictNonceModeEnabled() {
+    return process.env.CSP_STRICT_NONCE_MODE === 'true';
+}
+
 function getCspStage(isProduction: boolean): CspStage {
-    const fallbackStage = isProduction ? 'strict' : 'balanced';
+    const fallbackStage = isProduction ? 'compat' : 'balanced';
     const configuredStage = (process.env.CSP_STAGE || fallbackStage).toLowerCase();
 
     if (configuredStage === 'compat' || configuredStage === 'balanced' || configuredStage === 'strict') {
+        if (isProduction && configuredStage === 'strict' && !isStrictNonceModeEnabled()) {
+            return 'compat';
+        }
         return configuredStage;
     }
 


### PR DESCRIPTION
…P_STRICT_NONCE_MODE

Production previously defaulted to a strict CSP if CSP_STAGE was unset, which can blank-screen any route that doesn't propagate a request nonce.

- Flip the production fallback stage from `strict` to `compat`.
- Even when CSP_STAGE=strict is configured in production, downgrade to `compat` unless CSP_STRICT_NONCE_MODE=true is also set. This is a belt-and-suspenders check against accidental strict rollout before every route is verified.
- Cover the new behavior in csp.test.ts.