### PR TITLE
feat(community): event room threads + Reddit-parity actions + securit…

### DIFF
--- a/apps/mobile/app/(tabs)/community.tsx
+++ b/apps/mobile/app/(tabs)/community.tsx
@@ -25,6 +25,7 @@ import { MobilePage } from "../../src/components/chrome/MobilePage";
 import { ScreenState } from "../../src/components/chrome/ScreenState";
 import { CommunityNetworkingPersonCard } from "../../src/components/community/CommunityNetworkingPersonCard";
 import { CommunityNetworkingSpeakerCard } from "../../src/components/community/CommunityNetworkingSpeakerCard";
+import { CommunityRoomSheet } from "../../src/components/community/CommunityRoomSheet";
 import { formatCommunityTabCount } from "../../src/components/community/presentation";
 import { summarizeCommunityPost } from "../../src/lib/communityPresentation";
 import {
@@ -89,6 +90,40 @@ function getDisplayName(value: {
 
 function getCircleSlug(circle: MobileCommunityCircle): string {
   return circle.slug || circle.id;
+}
+
+const CIRCLE_ICON_MAP: Array<{
+  keywords: string[];
+  icon: keyof typeof FontAwesome.glyphMap;
+}> = [
+  { keywords: ["ai", "artificial", "machine", "ml", "llm", "gpt"], icon: "magic" },
+  { keywords: ["product", "pm", "roadmap"], icon: "th-large" },
+  { keywords: ["founder", "startup", "venture", "vc"], icon: "rocket" },
+  { keywords: ["engineer", "dev", "code", "software", "backend", "frontend", "fullstack"], icon: "code" },
+  { keywords: ["design", "ux", "ui", "figma", "creative"], icon: "paint-brush" },
+  { keywords: ["data", "analytics", "bi", "sql"], icon: "database" },
+  { keywords: ["marketing", "growth", "seo", "content"], icon: "bullhorn" },
+  { keywords: ["sales", "revenue", "crm", "bdr"], icon: "bar-chart" },
+  { keywords: ["mobile", "ios", "android", "react native"], icon: "mobile" },
+  { keywords: ["web", "frontend", "browser"], icon: "globe" },
+  { keywords: ["security", "privacy", "infosec", "cyber"], icon: "lock" },
+  { keywords: ["community", "networking", "social"], icon: "users" },
+  { keywords: ["finance", "fintech", "crypto", "defi", "invest"], icon: "money" },
+  { keywords: ["health", "wellness", "fitness", "bio"], icon: "heartbeat" },
+  { keywords: ["gaming", "game", "esports"], icon: "gamepad" },
+  { keywords: ["science", "research", "lab"], icon: "flask" },
+  { keywords: ["legal", "compliance", "policy"], icon: "balance-scale" },
+  { keywords: ["ops", "operations", "infra", "devops", "platform"], icon: "cogs" },
+];
+
+function getCircleIcon(name: string): keyof typeof FontAwesome.glyphMap {
+  const lower = name.toLowerCase();
+  for (const entry of CIRCLE_ICON_MAP) {
+    if (entry.keywords.some((kw) => lower.includes(kw))) {
+      return entry.icon;
+    }
+  }
+  return "users";
 }
 
 function getInitials(name: string): string {
@@ -168,20 +203,26 @@ function getRoomStatus(event: MobileCommunityNetworkingEvent): string {
   return `${formatShortRelativeTime(event.startTime)} · ${activityLabel}`;
 }
 
-function getRoomQuote(event: MobileCommunityNetworkingEvent): string {
-  if (event.attendeePreview.length > 0) {
-    return "Attendees are starting to coordinate.";
-  }
+function getCompactTime(startTime: string | null): string {
+  if (!startTime) return "Soon";
+  const diffMs = new Date(startTime).getTime() - Date.now();
+  const absMinutes = Math.max(1, Math.round(Math.abs(diffMs) / 60_000));
+  if (absMinutes < 60) return `${absMinutes}m`;
+  const hours = Math.round(absMinutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
 
-  if ((event.speakerPreview?.length ?? 0) > 0) {
-    return "Speaker signal is forming.";
+function getRoomCompactMeta(event: MobileCommunityNetworkingEvent): string {
+  const isActive =
+    (event.recentTrackerCount ?? 0) > 0 || event.visibleAttendeeCount > 0;
+  if (isActive) {
+    const count = event.visibleAttendeeCount || event.networkAttendingCount;
+    return count > 0
+      ? `Active · ${formatCommunityTabCount(count)} here`
+      : "Active now";
   }
-
-  if (event.visibleAttendeeCount > 0 || event.networkAttendingCount > 0) {
-    return "Early attendee momentum.";
-  }
-
-  return "Attendee signal is still forming.";
+  return getCompactTime(event.startTime);
 }
 
 function filterRooms(
@@ -264,6 +305,9 @@ export default function CommunityScreen() {
   const [activeTab, setActiveTab] = useState<CommunityTab>("pulse");
   const [roomLens, setRoomLens] = useState<RoomLens>("for_you");
   const [peopleLens, setPeopleLens] = useState<PeopleLens>("for_you");
+  const [activeRoomEventId, setActiveRoomEventId] = useState<string | null>(
+    null,
+  );
 
   const loadCommunity = useCallback(async (mode: LoadMode = "initial") => {
     const requestId = ++requestSequenceRef.current;
@@ -386,6 +430,7 @@ export default function CommunityScreen() {
                 home={home}
                 onOpenPeople={() => setActiveTab("people")}
                 onOpenRooms={() => setActiveTab("rooms")}
+                onOpenRoom={setActiveRoomEventId}
               />
             ) : null}
 
@@ -395,6 +440,7 @@ export default function CommunityScreen() {
                 followUps={home.followUpNow}
                 lens={roomLens}
                 onChangeLens={setRoomLens}
+                onOpenRoom={setActiveRoomEventId}
               />
             ) : null}
 
@@ -412,6 +458,10 @@ export default function CommunityScreen() {
           </>
         ) : null}
       </View>
+      <CommunityRoomSheet
+        eventId={activeRoomEventId}
+        onClose={() => setActiveRoomEventId(null)}
+      />
     </MobilePage>
   );
 }
@@ -431,7 +481,7 @@ function SegmentedTabs({
         styles.segmentedControl,
         {
           backgroundColor: tokens.colors.surfaceMuted,
-          borderRadius: tokens.radius.sm,
+          borderRadius: tokens.radius.xs,
         },
       ]}
     >
@@ -444,13 +494,8 @@ function SegmentedTabs({
           style={[
             styles.segmentedItem,
             activeTab === tab.id && {
-              backgroundColor: tokens.colors.surface,
-              borderRadius: tokens.radius.sm - 4,
-              shadowColor: tokens.shadow.shadowColor,
-              shadowOpacity: tokens.mode === "dark" ? 0.12 : 0.08,
-              shadowRadius: 8,
-              shadowOffset: { width: 0, height: 3 },
-              elevation: 2,
+              backgroundColor: tokens.colors.pillActive,
+              borderRadius: tokens.radius.xs,
             },
           ]}
         >
@@ -458,12 +503,13 @@ function SegmentedTabs({
             style={{
               color:
                 activeTab === tab.id
-                  ? tokens.colors.textPrimary
-                  : tokens.colors.textSecondary,
+                  ? tokens.colors.pillActiveText
+                  : tokens.colors.textTertiary,
               fontFamily: tokens.typography.sans,
-              fontSize: 15,
-              lineHeight: 20,
-              fontWeight: "800",
+              fontSize: 13,
+              lineHeight: 18,
+              fontWeight: "700",
+              letterSpacing: 0.1,
             }}
           >
             {tab.label}
@@ -477,10 +523,12 @@ function SegmentedTabs({
 function PulseTab({
   home,
   onOpenPeople,
+  onOpenRoom,
   onOpenRooms,
 }: {
   home: MobileCommunityHome;
   onOpenPeople: () => void;
+  onOpenRoom: (eventId: string) => void;
   onOpenRooms: () => void;
 }) {
   const { tokens } = useAppTheme();
@@ -515,6 +563,7 @@ function PulseTab({
               styles.activityCard,
               {
                 backgroundColor: tokens.colors.surface,
+                borderColor: tokens.colors.border,
                 shadowColor: tokens.shadow.shadowColor,
               },
             ]}
@@ -537,18 +586,7 @@ function PulseTab({
             actionLabel="See all"
             onPress={onOpenRooms}
           />
-          <View style={styles.stack}>
-            {roomPreview.map((event, index) => (
-              <RoomCard
-                key={event.id}
-                compact={index > 0}
-                event={event}
-                primaryActionLabel={
-                  index === 0 ? "Open Room" : "Introduce yourself"
-                }
-              />
-            ))}
-          </View>
+          <RoomList events={roomPreview} onOpenRoom={onOpenRoom} />
         </>
       ) : null}
 
@@ -618,6 +656,7 @@ function PulseSummaryCard({
         styles.summaryCard,
         {
           backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
           shadowColor: tokens.shadow.shadowColor,
         },
       ]}
@@ -661,7 +700,7 @@ function SummaryRow({
         pressed && styles.pressed,
       ]}
     >
-      <FontAwesome name={icon} size={19} color={tokens.colors.success} />
+      <FontAwesome name={icon} size={19} color={tokens.colors.accent} />
       <Text
         style={[
           styles.summaryText,
@@ -687,11 +726,13 @@ function RoomsTab({
   followUps,
   lens,
   onChangeLens,
+  onOpenRoom,
 }: {
   activeRooms: MobileCommunityNetworkingEvent[];
   followUps: MobileCommunityNetworkingFollowUpCard[];
   lens: RoomLens;
   onChangeLens: (lens: RoomLens) => void;
+  onOpenRoom: (eventId: string) => void;
 }) {
   const pastFollowUp = followUps[0];
   const pastEvent = pastFollowUp ? getPrimaryEvent(pastFollowUp) : null;
@@ -714,18 +755,7 @@ function RoomsTab({
           <SectionEmptyNote title="No past rooms with follow-up yet" />
         )
       ) : activeRooms.length > 0 ? (
-        <View style={styles.stack}>
-          {activeRooms.map((event, index) => (
-            <RoomCard
-              key={event.id}
-              event={event}
-              primaryActionLabel={index === 0 ? "Open Room" : "Open Room"}
-              secondaryActionLabel={
-                event.viewerContext === "attending" ? "Going" : "View Event"
-              }
-            />
-          ))}
-        </View>
+        <RoomList events={activeRooms} onOpenRoom={onOpenRoom} />
       ) : (
         <SectionEmptyNote title="No rooms in this view yet" />
       )}
@@ -733,113 +763,100 @@ function RoomsTab({
   );
 }
 
-function RoomCard({
-  event,
+function RoomList({
+  events,
+  onOpenRoom,
 }: {
-  compact?: boolean;
+  events: MobileCommunityNetworkingEvent[];
+  onOpenRoom: (eventId: string) => void;
+}) {
+  const { tokens } = useAppTheme();
+
+  return (
+    <View
+      style={[
+        styles.roomList,
+        {
+          backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
+          borderRadius: tokens.radius.sm,
+        },
+      ]}
+    >
+      {events.map((event, index) => (
+        <RoomRow
+          key={event.id}
+          event={event}
+          isLast={index === events.length - 1}
+          onOpenRoom={onOpenRoom}
+        />
+      ))}
+    </View>
+  );
+}
+
+function RoomRow({
+  event,
+  isLast,
+  onOpenRoom,
+}: {
   event: MobileCommunityNetworkingEvent;
-  primaryActionLabel: string;
-  secondaryActionLabel?: string;
+  isLast: boolean;
+  onOpenRoom: (eventId: string) => void;
 }) {
   const { tokens } = useAppTheme();
   const isWarm =
     event.viewerContext === "attending" || event.visibleAttendeeCount > 0;
-  const status = getRoomStatus(event);
-  const discussionPreview = getRoomQuote(event);
+  const meta = getRoomCompactMeta(event);
 
   return (
     <Pressable
       accessibilityLabel={`Open room for ${event.title}`}
       accessibilityRole="button"
-      onPress={() => router.push(`/event/${event.id}`)}
+      onPress={() => onOpenRoom(event.id)}
       style={({ pressed }) => [
-        styles.roomCard,
-        {
-          backgroundColor: "#111214",
-          borderColor: "rgba(255, 255, 255, 0.07)",
-          borderRadius: 10,
-          shadowColor: "#000000",
+        styles.roomRow,
+        !isLast && {
+          borderBottomWidth: 1,
+          borderBottomColor: tokens.colors.divider,
         },
-        pressed && styles.roomCardPressed,
+        pressed && { backgroundColor: tokens.colors.surfaceMuted },
       ]}
     >
-      <View style={styles.roomTopRow}>
-        <View style={styles.roomCopy}>
-          <Text
-            style={[
-              styles.roomReason,
-              {
-                color: "rgba(255, 255, 255, 0.5)",
-                fontFamily: tokens.typography.sans,
-              },
-            ]}
-          >
-            {getRoomReason(event)}
-          </Text>
-          <Text
-            numberOfLines={2}
-            style={[
-              styles.roomEventTitle,
-              {
-                color: "#F7F8F8",
-                fontFamily: tokens.typography.sans,
-              },
-            ]}
-          >
-            {event.title}
-          </Text>
-          <View style={styles.roomTelemetryRow}>
-            <View
-              style={[
-                styles.roomStatusDot,
-                {
-                  backgroundColor: isWarm
-                    ? "#5EEAD4"
-                    : "rgba(255, 255, 255, 0.34)",
-                },
-              ]}
-            />
-            <Text
-              numberOfLines={1}
-              style={[
-                styles.roomTelemetryText,
-                {
-                  color: "rgba(255, 255, 255, 0.4)",
-                  fontFamily: tokens.typography.sans,
-                },
-              ]}
-            >
-              {status}
-            </Text>
-          </View>
-          <Text
-            numberOfLines={1}
-            style={[
-              styles.roomSnippet,
-              {
-                color: "rgba(255, 255, 255, 0.46)",
-                fontFamily: tokens.typography.sans,
-              },
-            ]}
-          >
-            {discussionPreview}
-          </Text>
-        </View>
-
+      <Text
+        numberOfLines={1}
+        style={[
+          styles.roomRowTitle,
+          {
+            color: tokens.colors.textPrimary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {event.title}
+      </Text>
+      <View style={styles.roomRowMeta}>
         <View
           style={[
-            styles.roomArrow,
+            styles.roomStatusDot,
             {
-              borderColor: "rgba(255, 255, 255, 0.07)",
+              backgroundColor: isWarm
+                ? tokens.colors.accent
+                : tokens.colors.textTertiary,
+            },
+          ]}
+        />
+        <Text
+          style={[
+            styles.roomRowMetaText,
+            {
+              color: tokens.colors.textTertiary,
+              fontFamily: tokens.typography.sans,
             },
           ]}
         >
-          <FontAwesome
-            name="long-arrow-right"
-            size={10}
-            color="rgba(255, 255, 255, 0.5)"
-          />
-        </View>
+          {meta}
+        </Text>
       </View>
     </Pressable>
   );
@@ -991,7 +1008,7 @@ function ActivityRow({
           style={[
             styles.activityBody,
             {
-              color: tokens.colors.textPrimary,
+              color: tokens.colors.textSecondary,
               fontFamily: tokens.typography.sans,
             },
           ]}
@@ -1002,7 +1019,7 @@ function ActivityRow({
           style={[
             styles.activityMeta,
             {
-              color: tokens.colors.success,
+              color: tokens.colors.accent,
               fontFamily: tokens.typography.sans,
             },
           ]}
@@ -1037,14 +1054,16 @@ function CircleCard({ circle }: { circle: MobileCommunityCircle }) {
           styles.circleIcon,
           {
             backgroundColor: tokens.colors.surfaceMuted,
-            borderRadius: tokens.radius.sm,
+            borderRadius: tokens.radius.xs,
+            borderWidth: 1,
+            borderColor: tokens.colors.border,
           },
         ]}
       >
         <FontAwesome
-          name="microchip"
-          size={18}
-          color={tokens.colors.textPrimary}
+          name={getCircleIcon(circle.name)}
+          size={16}
+          color={tokens.colors.textTertiary}
         />
       </View>
       <Text
@@ -1062,7 +1081,7 @@ function CircleCard({ circle }: { circle: MobileCommunityCircle }) {
         style={[
           styles.cardMeta,
           {
-            color: tokens.colors.textSecondary,
+            color: tokens.colors.textTertiary,
             fontFamily: tokens.typography.sans,
           },
         ]}
@@ -1072,7 +1091,12 @@ function CircleCard({ circle }: { circle: MobileCommunityCircle }) {
       <Text
         style={[
           styles.circleSignal,
-          { color: tokens.colors.success, fontFamily: tokens.typography.sans },
+          {
+            color: circle.isJoined
+              ? tokens.colors.accent
+              : tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+          },
         ]}
       >
         {circle.isJoined ? "Joined" : "Discover"}
@@ -1181,11 +1205,13 @@ function PastRoomCard({
   return (
     <View
       style={[
-        styles.roomCard,
+        styles.roomList,
         {
           backgroundColor: tokens.colors.surfaceStrong,
           borderColor: tokens.colors.border,
-          borderRadius: tokens.radius.md,
+          borderRadius: tokens.radius.sm,
+          padding: 12,
+          gap: 8,
         },
       ]}
     >
@@ -1316,7 +1342,7 @@ function LensRail({
                 activeId === item.id
                   ? tokens.colors.pillActive
                   : tokens.colors.surfaceMuted,
-              borderRadius: tokens.radius.md,
+              borderRadius: tokens.radius.xs,
             },
             pressed && styles.pressed,
           ]}
@@ -1348,7 +1374,7 @@ function SectionTitle({ title }: { title: string }) {
       style={[
         styles.sectionTitle,
         {
-          color: tokens.colors.textPrimary,
+          color: tokens.colors.textTertiary,
           fontFamily: tokens.typography.sans,
         },
       ]}
@@ -1377,7 +1403,7 @@ function SectionHeaderLink({
           style={[
             styles.headerLink,
             {
-              color: tokens.colors.textPrimary,
+              color: tokens.colors.accent,
               fontFamily: tokens.typography.sans,
             },
           ]}
@@ -1458,7 +1484,8 @@ const styles = StyleSheet.create({
     lineHeight: 18,
   },
   activityCard: {
-    borderRadius: 6,
+    borderRadius: 4,
+    borderWidth: 1,
     overflow: "hidden",
     shadowOpacity: 0,
     shadowRadius: 0,
@@ -1609,122 +1636,40 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: "700",
   },
-  roomCard: {
+  roomList: {
     borderWidth: 1,
-    padding: 12,
-    shadowOpacity: 0.18,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 8 },
-    elevation: 1,
+    overflow: "hidden",
   },
-  roomCardPressed: {
-    opacity: 0.9,
-    transform: [{ scale: 0.995 }],
-  },
-  roomActionRow: {
+  roomRow: {
     alignItems: "center",
     flexDirection: "row",
-    gap: 8,
-    paddingTop: 2,
+    gap: 10,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
   },
-  roomArrow: {
+  roomRowMeta: {
     alignItems: "center",
-    borderWidth: 1,
-    height: 21,
-    justifyContent: "center",
-    width: 21,
-  },
-  roomCopy: {
-    flex: 1,
-    gap: 3,
-  },
-  roomEventTitle: {
-    fontSize: 16,
-    fontWeight: "800",
-    letterSpacing: -0.25,
-    lineHeight: 18,
-  },
-  roomHeaderRow: {
-    alignItems: "flex-start",
     flexDirection: "row",
-    gap: 12,
-    justifyContent: "space-between",
+    gap: 5,
+    flexShrink: 0,
   },
-  roomIcon: {
-    alignItems: "center",
-    height: 46,
-    justifyContent: "center",
-    width: 46,
-  },
-  roomQuote: {
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-  },
-  roomQuoteText: {
-    fontSize: 15,
-    fontWeight: "600",
-    lineHeight: 21,
-  },
-  roomPrimaryAction: {
-    alignItems: "center",
-    borderWidth: 1,
-    justifyContent: "center",
-    minHeight: 28,
-    paddingHorizontal: 10,
-  },
-  roomPrimaryActionText: {
-    fontSize: 12,
-    fontWeight: "800",
-    lineHeight: 15,
-  },
-  roomReason: {
-    fontSize: 10,
-    fontWeight: "700",
-    letterSpacing: 0,
-    lineHeight: 12,
-  },
-  roomSecondaryAction: {
-    alignItems: "center",
-    borderWidth: 1,
-    justifyContent: "center",
-    minHeight: 28,
-    paddingHorizontal: 10,
-  },
-  roomSecondaryActionText: {
-    fontSize: 12,
-    fontWeight: "800",
-    lineHeight: 15,
-  },
-  roomSnippet: {
+  roomRowMetaText: {
     fontSize: 12,
     fontWeight: "500",
-    lineHeight: 15,
-    paddingTop: 1,
+    lineHeight: 16,
+  },
+  roomRowTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: "600",
+    letterSpacing: -0.1,
+    lineHeight: 18,
   },
   roomStatusDot: {
     borderRadius: 2,
     height: 4,
     width: 4,
-  },
-  roomTelemetryRow: {
-    alignItems: "center",
-    flexDirection: "row",
-    gap: 6,
-  },
-  roomTelemetryText: {
-    flex: 1,
-    fontSize: 11,
-    fontWeight: "500",
-    lineHeight: 14,
-  },
-  roomTitleWrap: {
-    flex: 1,
-    gap: 5,
-  },
-  roomTopRow: {
-    alignItems: "flex-start",
-    flexDirection: "row",
-    gap: 10,
   },
   secondaryAction: {
     alignItems: "center",
@@ -1744,11 +1689,11 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   sectionTitle: {
-    fontSize: 16,
+    fontSize: 11,
     fontWeight: "700",
-    letterSpacing: -0.1,
-    lineHeight: 20,
-    paddingTop: 4,
+    letterSpacing: 0.9,
+    lineHeight: 16,
+    paddingTop: 6,
   },
   segmentedControl: {
     flexDirection: "row",
@@ -1764,7 +1709,8 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   summaryCard: {
-    borderRadius: 6,
+    borderRadius: 4,
+    borderWidth: 1,
     overflow: "hidden",
     shadowOpacity: 0,
     shadowRadius: 0,

--- a/apps/mobile/app/event/[id]/threads/[threadId].tsx
+++ b/apps/mobile/app/event/[id]/threads/[threadId].tsx
@@ -1,0 +1,1899 @@
+import type {
+  MobileCommunityRoomCommentSort,
+  MobileCommunityRoomThreadChildComment,
+  MobileCommunityRoomThreadComment,
+  MobileCommunityRoomThreadDetail,
+} from "@kurecal/domain";
+import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Constants from "expo-constants";
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import {
+  HeaderActionButton,
+  MobilePage,
+} from "../../../../src/components/chrome/MobilePage";
+import { ScreenState } from "../../../../src/components/chrome/ScreenState";
+import {
+  CommunityThreadActionMenu,
+  type ThreadActionKey,
+  type ThreadActionOption,
+} from "../../../../src/components/community/CommunityThreadActionMenu";
+import { CommunityThreadReportSheet } from "../../../../src/components/community/CommunityThreadReportSheet";
+import {
+  createMobileEventThreadComment,
+  deleteMobileEventThread,
+  deleteMobileEventThreadComment,
+  loadMobileEventThread,
+  updateMobileEventThread,
+  updateMobileEventThreadComment,
+} from "../../../../src/lib/mobileApi";
+import { useAppTheme } from "../../../../src/providers/ThemeProvider";
+
+type MenuTarget =
+  | { kind: "thread"; id: string; authorName: string; isAuthor: boolean }
+  | {
+      kind: "comment";
+      id: string;
+      authorName: string;
+      isAuthor: boolean;
+      parentId: string | null;
+    };
+
+type EditTarget =
+  | { kind: "thread"; id: string; title: string; body: string }
+  | { kind: "comment"; id: string; body: string };
+
+type ReportTarget =
+  | { kind: "thread"; id: string }
+  | { kind: "comment"; id: string };
+
+interface PendingComment {
+  localId: string;
+  body: string;
+  parentRootId: string | null;
+  status: "pending" | "failed";
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function formatRelative(value: string): string {
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return "Recently";
+  const diff = Date.now() - ts;
+  const minutes = Math.max(1, Math.round(diff / 60_000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatReplyLabel(count: number): string {
+  if (count === 0) return "No replies";
+  if (count === 1) return "1 reply";
+  return `${count} replies`;
+}
+
+function makeLocalId(): string {
+  return `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUuidString(value: string | null | undefined): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
+function isSafeAvatarUrl(url: string | null | undefined): url is string {
+  if (!url) return false;
+  // Only allow http(s) — React Native <Image> will otherwise happily render
+  // `data:`, `file:`, or even `javascript:` schemes on some platforms.
+  return /^https?:\/\//i.test(url);
+}
+
+function findCommentById(
+  comments: MobileCommunityRoomThreadComment[],
+  id: string,
+):
+  | MobileCommunityRoomThreadComment
+  | MobileCommunityRoomThreadChildComment
+  | null {
+  for (const comment of comments) {
+    if (comment.id === id) return comment;
+    for (const reply of comment.replies) {
+      if (reply.id === id) return reply;
+    }
+  }
+  return null;
+}
+
+function buildMenuOptions(target: MenuTarget): ThreadActionOption[] {
+  const options: ThreadActionOption[] = [];
+  if (target.isAuthor) {
+    options.push({ key: "edit", label: "Edit" });
+    options.push({ key: "delete", label: "Delete", destructive: true });
+  } else {
+    options.push({ key: "report", label: "Report" });
+  }
+  options.push({ key: "copyLink", label: "Copy link" });
+  options.push({ key: "cancel", label: "Cancel" });
+  return options;
+}
+
+export default function EventThreadDetailScreen() {
+  const { tokens } = useAppTheme();
+  const params = useLocalSearchParams<{
+    id: string | string[];
+    threadId: string | string[];
+    comment?: string | string[];
+  }>();
+  const eventId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const threadId = Array.isArray(params.threadId)
+    ? params.threadId[0]
+    : params.threadId;
+  const rawPermalinkCommentId = Array.isArray(params.comment)
+    ? params.comment[0]
+    : params.comment;
+  // Reject malformed/garbage values up-front so they never reach the ref map
+  // or the scroll/measurement code paths.
+  const initialPermalinkCommentId = isValidUuidString(rawPermalinkCommentId)
+    ? rawPermalinkCommentId
+    : undefined;
+
+  const [detail, setDetail] = useState<MobileCommunityRoomThreadDetail | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [replyText, setReplyText] = useState("");
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [composerActive, setComposerActive] = useState(false);
+  const [replyingTo, setReplyingTo] = useState<{
+    rootId: string;
+    authorName: string;
+  } | null>(null);
+  const [pending, setPending] = useState<PendingComment[]>([]);
+  const [posting, setPosting] = useState(false);
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [sort, setSort] = useState<MobileCommunityRoomCommentSort>("oldest");
+  const [menuTarget, setMenuTarget] = useState<MenuTarget | null>(null);
+  const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
+  const [reportTarget, setReportTarget] = useState<ReportTarget | null>(null);
+  const [highlightedCommentId, setHighlightedCommentId] = useState<
+    string | null
+  >(null);
+  const requestSequenceRef = useRef(0);
+  const scrollRef = useRef<ScrollView | null>(null);
+  const commentRefs = useRef<Map<string, View>>(new Map());
+  const permalinkAppliedRef = useRef(false);
+
+  const load = useCallback(async () => {
+    if (!eventId || !threadId) {
+      setError("Thread id is missing");
+      setLoading(false);
+      return;
+    }
+
+    const requestId = ++requestSequenceRef.current;
+    setLoading(true);
+    try {
+      const data = await loadMobileEventThread(eventId, threadId, sort);
+      if (requestId !== requestSequenceRef.current) return;
+      setDetail(data);
+      setError(null);
+    } catch (nextError) {
+      if (requestId !== requestSequenceRef.current) return;
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Unable to load this thread",
+      );
+    } finally {
+      if (requestId === requestSequenceRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [eventId, threadId, sort]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load]),
+  );
+
+  const postComment = useCallback(
+    async (body: string, parentRootId: string | null, localId: string) => {
+      if (!eventId || !threadId) return;
+      try {
+        await createMobileEventThreadComment(eventId, threadId, {
+          body,
+          parentCommentId: parentRootId,
+        });
+        setPending((prev) => prev.filter((entry) => entry.localId !== localId));
+        await load();
+      } catch (nextError) {
+        console.warn("createMobileEventThreadComment failed", nextError);
+        setReplyError("Couldn't post your reply. Try again.");
+        setPending((prev) =>
+          prev.map((entry) =>
+            entry.localId === localId ? { ...entry, status: "failed" } : entry,
+          ),
+        );
+      }
+    },
+    [eventId, threadId, load],
+  );
+
+  const handlePostReply = async () => {
+    if (!detail) return;
+    // Block double-tap: a second invocation while the first POST is in
+    // flight would create a duplicate stub (and duplicate row).
+    if (posting) return;
+    const trimmed = replyText.trim();
+    if (!trimmed) {
+      setReplyError("Add a reply before posting.");
+      return;
+    }
+    setReplyError(null);
+    setPosting(true);
+    const localId = makeLocalId();
+    const parentRootId = replyingTo?.rootId ?? null;
+    setPending((prev) => [
+      ...prev,
+      { localId, body: trimmed, parentRootId, status: "pending" },
+    ]);
+    setReplyText("");
+    setComposerActive(false);
+    setReplyingTo(null);
+    try {
+      await postComment(trimmed, parentRootId, localId);
+    } finally {
+      setPosting(false);
+    }
+  };
+
+  const handleRetry = (entry: PendingComment) => {
+    setPending((prev) =>
+      prev.map((p) =>
+        p.localId === entry.localId ? { ...p, status: "pending" } : p,
+      ),
+    );
+    void postComment(entry.body, entry.parentRootId, entry.localId);
+  };
+
+  const handleDismissFailed = (localId: string) => {
+    setPending((prev) => prev.filter((entry) => entry.localId !== localId));
+  };
+
+  const openComposer = ({
+    rootId,
+    authorName,
+  }: { rootId: string; authorName: string } | { rootId?: undefined; authorName?: undefined } = {}) => {
+    setReplyError(null);
+    if (rootId && authorName) {
+      setReplyingTo({ rootId, authorName });
+    } else {
+      setReplyingTo(null);
+    }
+    setComposerActive(true);
+  };
+
+  const cancelComposer = () => {
+    setComposerActive(false);
+    setReplyError(null);
+    setReplyText("");
+    setReplyingTo(null);
+  };
+
+  const cancelReplyTarget = () => setReplyingTo(null);
+
+  // Build the list of pending top-level stubs (those without a parent root)
+  // for rendering at the end of the comments list.
+  const topLevelPending = useMemo(
+    () => pending.filter((entry) => entry.parentRootId === null),
+    [pending],
+  );
+
+  // Pending child stubs keyed by their parent root id, so each top-level
+  // comment can pick up its pending replies.
+  const pendingByParent = useMemo(() => {
+    const map = new Map<string, PendingComment[]>();
+    for (const entry of pending) {
+      if (!entry.parentRootId) continue;
+      const existing = map.get(entry.parentRootId);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        map.set(entry.parentRootId, [entry]);
+      }
+    }
+    return map;
+  }, [pending]);
+
+  // Scroll to and briefly highlight a permalink-targeted comment after the
+  // thread renders. Runs only on the first successful load so subsequent
+  // refetches don't re-trigger the scroll.
+  useEffect(() => {
+    if (!initialPermalinkCommentId) return;
+    if (!detail) return;
+    if (permalinkAppliedRef.current) return;
+    permalinkAppliedRef.current = true;
+
+    // Defer to next frame so the comment Views have been laid out.
+    const timer = setTimeout(() => {
+      const view = commentRefs.current.get(initialPermalinkCommentId);
+      const scroller = scrollRef.current;
+      if (!view || !scroller) return;
+      view.measureLayout(
+        // measureLayout's second arg expects a node handle; ScrollView's ref
+        // exposes one via `getInnerViewNode` on iOS / native nodes elsewhere.
+        // Pass the ScrollView ref as `any` to avoid wrestling with types.
+        scroller as unknown as number,
+        (_x, y) => {
+          scroller.scrollTo({
+            y: Math.max(0, y - 24),
+            animated: true,
+          });
+        },
+        () => {
+          /* swallow */
+        },
+      );
+      setHighlightedCommentId(initialPermalinkCommentId);
+      setTimeout(() => setHighlightedCommentId(null), 2200);
+    }, 80);
+
+    return () => clearTimeout(timer);
+  }, [detail, initialPermalinkCommentId]);
+
+  const handleSortChange = (next: MobileCommunityRoomCommentSort) => {
+    if (next === sort) return;
+    setSort(next);
+  };
+
+  const handleOpenThreadMenu = () => {
+    if (!detail) return;
+    setMenuTarget({
+      kind: "thread",
+      id: detail.thread.id,
+      authorName:
+        detail.thread.author.fullName || `@${detail.thread.author.username}`,
+      isAuthor: detail.thread.isAuthor,
+    });
+  };
+
+  const handleOpenCommentMenu = (
+    comment: MobileCommunityRoomThreadComment | MobileCommunityRoomThreadChildComment,
+  ) => {
+    setMenuTarget({
+      kind: "comment",
+      id: comment.id,
+      authorName: comment.author.fullName || `@${comment.author.username}`,
+      isAuthor: comment.isAuthor,
+      parentId: comment.parentId,
+    });
+  };
+
+  const handleCopyLink = async (kind: "thread" | "comment", id: string) => {
+    if (!eventId || !threadId) return;
+    // Build a deep link using the scheme registered for the current variant
+    // (kurecal-dev in dev, kurecal in production). Tapping it in another app
+    // opens us at the right route.
+    const schemeRaw = Constants.expoConfig?.scheme;
+    const scheme =
+      typeof schemeRaw === "string" && schemeRaw.length > 0
+        ? schemeRaw
+        : "kurecal";
+    const path = `/event/${eventId}/threads/${threadId}`;
+    const query = kind === "comment" ? `?comment=${id}` : "";
+    const url = `${scheme}://${path}${query}`;
+
+    try {
+      // The native share sheet exposes both "Copy" and direct share targets,
+      // so this works whether the user wants to copy or send the link. Using
+      // React Native's built-in Share avoids the expo-clipboard native
+      // module, which would otherwise require a dev-client rebuild.
+      await Share.share({ message: url, url });
+    } catch (nextError) {
+      // iOS throws on cancel; ignore silently. Real failures still log.
+      console.warn("Share link failed", nextError);
+    }
+  };
+
+  const handleConfirmDelete = (target: MenuTarget) => {
+    const label = target.kind === "thread" ? "thread" : "comment";
+    Alert.alert(
+      `Delete ${label}?`,
+      `This can't be undone.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            void performDelete(target);
+          },
+        },
+      ],
+      { cancelable: true },
+    );
+  };
+
+  const performDelete = async (target: MenuTarget) => {
+    if (!eventId || !threadId) return;
+    try {
+      if (target.kind === "thread") {
+        await deleteMobileEventThread(eventId, threadId);
+        router.back();
+      } else {
+        await deleteMobileEventThreadComment(eventId, threadId, target.id);
+        await load();
+      }
+    } catch (nextError) {
+      console.warn("delete community thread/comment failed", nextError);
+      Alert.alert("Delete failed", "Couldn't delete that. Try again.");
+    }
+  };
+
+  const handleStartEdit = (target: MenuTarget) => {
+    if (target.kind === "thread") {
+      if (!detail) return;
+      setEditTarget({
+        kind: "thread",
+        id: target.id,
+        title: detail.thread.title,
+        body: detail.thread.body,
+      });
+      return;
+    }
+    const found = findCommentById(detail?.comments ?? [], target.id);
+    if (!found || found.isDeleted) return;
+    setEditTarget({ kind: "comment", id: target.id, body: found.body });
+  };
+
+  const handleSaveThreadEdit = async (title: string, body: string) => {
+    if (!eventId || !threadId) return;
+    if (savingEdit) return;
+    setSavingEdit(true);
+    try {
+      await updateMobileEventThread(eventId, threadId, { title, body });
+      setEditTarget(null);
+      await load();
+    } catch (nextError) {
+      // Surface a generic message; log the underlying cause for engineers.
+      console.warn("updateMobileEventThread failed", nextError);
+      Alert.alert("Edit failed", "Couldn't save those edits. Try again.");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const handleSaveCommentEdit = async (commentId: string, body: string) => {
+    if (!eventId || !threadId) return;
+    if (savingEdit) return;
+    setSavingEdit(true);
+    try {
+      await updateMobileEventThreadComment(eventId, threadId, commentId, {
+        body,
+      });
+      setEditTarget(null);
+      await load();
+    } catch (nextError) {
+      console.warn("updateMobileEventThreadComment failed", nextError);
+      Alert.alert("Edit failed", "Couldn't save those edits. Try again.");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const handleSelectMenuAction = (key: ThreadActionKey) => {
+    const target = menuTarget;
+    setMenuTarget(null);
+    if (!target) return;
+    switch (key) {
+      case "edit":
+        handleStartEdit(target);
+        return;
+      case "delete":
+        handleConfirmDelete(target);
+        return;
+      case "copyLink":
+        void handleCopyLink(target.kind, target.id);
+        return;
+      case "report":
+        setReportTarget({ kind: target.kind, id: target.id });
+        return;
+      case "cancel":
+      default:
+        return;
+    }
+  };
+
+  const registerCommentRef = (id: string, node: View | null) => {
+    if (node) {
+      commentRefs.current.set(id, node);
+    } else {
+      commentRefs.current.delete(id);
+    }
+  };
+
+  return (
+    <MobilePage
+      title={detail?.thread.title ?? "Thread"}
+      action={
+        <HeaderActionButton label="Back" onPress={() => router.back()} />
+      }
+      scrollRef={scrollRef}
+    >
+      {loading && !detail ? (
+        <ScreenState
+          mode="loading"
+          title="Loading thread"
+          description="Pulling the full discussion."
+        />
+      ) : null}
+
+      {error && !detail ? (
+        <ScreenState
+          mode="error"
+          title="Thread unavailable"
+          description={error}
+          action={
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => void load()}
+              style={({ pressed }) => [
+                styles.retryButton,
+                {
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                },
+                pressed && styles.pressed,
+              ]}
+            >
+              <Text
+                style={{
+                  color: tokens.colors.textPrimary,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 13,
+                  fontWeight: "700",
+                }}
+              >
+                Try again
+              </Text>
+            </Pressable>
+          }
+        />
+      ) : null}
+
+      {detail ? (
+        <View style={styles.stack}>
+          {editTarget?.kind === "thread" && editTarget.id === detail.thread.id ? (
+            <ThreadEditCard
+              initialBody={editTarget.body}
+              initialTitle={editTarget.title}
+              onCancel={() => setEditTarget(null)}
+              onSave={(title, body) => void handleSaveThreadEdit(title, body)}
+            />
+          ) : (
+            <>
+              <View style={styles.bylineRow}>
+                <ThreadByline thread={detail.thread} />
+                <OverflowButton onPress={handleOpenThreadMenu} />
+              </View>
+
+              <Text
+                style={[
+                  styles.body,
+                  {
+                    color: tokens.colors.textPrimary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                {detail.thread.body}
+                {detail.thread.editedAt ? (
+                  <Text
+                    style={{
+                      color: tokens.colors.textTertiary,
+                      fontFamily: tokens.typography.sans,
+                      fontSize: 12,
+                      fontWeight: "500",
+                    }}
+                  >
+                    {"  "}(edited)
+                  </Text>
+                ) : null}
+              </Text>
+            </>
+          )}
+
+          <View
+            style={[
+              styles.divider,
+              { backgroundColor: tokens.colors.divider },
+            ]}
+          />
+
+          <Composer
+            active={composerActive}
+            error={replyError}
+            posting={posting}
+            replyingTo={replyingTo}
+            text={replyText}
+            onCancel={cancelComposer}
+            onCancelReplyTarget={cancelReplyTarget}
+            onChangeText={setReplyText}
+            onOpen={() => openComposer()}
+            onSubmit={handlePostReply}
+          />
+
+          {detail.thread.commentCount + pending.length === 0 ? (
+            <Text
+              style={[
+                styles.emptyHint,
+                {
+                  color: tokens.colors.textTertiary,
+                  fontFamily: tokens.typography.sans,
+                },
+              ]}
+            >
+              Be the first to reply.
+            </Text>
+          ) : (
+            <View style={styles.commentsHeader}>
+              <Text
+                style={[
+                  styles.commentsLabel,
+                  {
+                    color: tokens.colors.textTertiary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                {formatReplyLabel(detail.thread.commentCount + pending.length)}
+              </Text>
+              <SortToggle
+                sort={sort}
+                onChange={handleSortChange}
+              />
+            </View>
+          )}
+
+          {detail.comments.map((comment) => (
+            <CommentBranch
+              key={comment.id}
+              comment={comment}
+              editTarget={editTarget}
+              highlightedCommentId={highlightedCommentId}
+              pendingChildren={pendingByParent.get(comment.id) ?? []}
+              onCancelEdit={() => setEditTarget(null)}
+              onDismissFailed={handleDismissFailed}
+              onOpenMenu={handleOpenCommentMenu}
+              onRegisterRef={registerCommentRef}
+              onReplyToRoot={(rootId, authorName) =>
+                openComposer({ rootId, authorName })
+              }
+              onRetry={handleRetry}
+              onSaveEdit={handleSaveCommentEdit}
+            />
+          ))}
+
+          {topLevelPending.map((entry) => (
+            <PendingRow
+              key={entry.localId}
+              entry={entry}
+              onDismiss={() => handleDismissFailed(entry.localId)}
+              onRetry={() => handleRetry(entry)}
+            />
+          ))}
+        </View>
+      ) : null}
+
+      <CommunityThreadActionMenu
+        onDismiss={() => setMenuTarget(null)}
+        onSelect={handleSelectMenuAction}
+        options={menuTarget ? buildMenuOptions(menuTarget) : []}
+        title={menuTarget ? menuTarget.authorName : undefined}
+        visible={menuTarget !== null}
+      />
+
+      <CommunityThreadReportSheet
+        onDismiss={() => setReportTarget(null)}
+        subjectId={reportTarget?.id ?? null}
+        subjectType={
+          reportTarget?.kind === "thread"
+            ? "event_thread"
+            : "event_thread_comment"
+        }
+        visible={reportTarget !== null}
+      />
+    </MobilePage>
+  );
+}
+
+function Composer({
+  active,
+  error,
+  posting,
+  replyingTo,
+  text,
+  onCancel,
+  onCancelReplyTarget,
+  onChangeText,
+  onOpen,
+  onSubmit,
+}: {
+  active: boolean;
+  error: string | null;
+  posting: boolean;
+  replyingTo: { rootId: string; authorName: string } | null;
+  text: string;
+  onCancel: () => void;
+  onCancelReplyTarget: () => void;
+  onChangeText: (value: string) => void;
+  onOpen: () => void;
+  onSubmit: () => void;
+}) {
+  const { tokens } = useAppTheme();
+  // Disable Post until there's text AND no in-flight create. The second
+  // condition is what blocks the double-tap exploit at the visual layer.
+  const canPost = text.trim().length > 0 && !posting;
+
+  if (!active) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        onPress={onOpen}
+        style={({ pressed }) => [
+          styles.composerCollapsed,
+          {
+            backgroundColor: tokens.colors.surface,
+            borderColor: tokens.colors.border,
+            borderRadius: tokens.radius.sm,
+          },
+          pressed && { backgroundColor: tokens.colors.surfaceMuted },
+        ]}
+      >
+        <Text
+          style={[
+            styles.composerCollapsedText,
+            {
+              color: tokens.colors.textTertiary,
+              fontFamily: tokens.typography.sans,
+            },
+          ]}
+        >
+          Add a comment…
+        </Text>
+      </Pressable>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.composerActive,
+        {
+          backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
+          borderRadius: tokens.radius.sm,
+        },
+      ]}
+    >
+      {replyingTo ? (
+        <View
+          style={[
+            styles.replyBanner,
+            {
+              backgroundColor: tokens.colors.accentSoft,
+              borderRadius: tokens.radius.xs,
+            },
+          ]}
+        >
+          <Text
+            numberOfLines={1}
+            style={{
+              color: tokens.colors.accent,
+              flex: 1,
+              fontFamily: tokens.typography.sans,
+              fontSize: 12,
+              fontWeight: "700",
+            }}
+          >
+            Replying to {replyingTo.authorName}
+          </Text>
+          <Pressable
+            accessibilityLabel="Cancel reply target"
+            onPress={onCancelReplyTarget}
+            style={({ pressed }) => [pressed && styles.pressed]}
+          >
+            <Text
+              style={{
+                color: tokens.colors.accent,
+                fontFamily: tokens.typography.sans,
+                fontSize: 12,
+                fontWeight: "700",
+              }}
+            >
+              ×
+            </Text>
+          </Pressable>
+        </View>
+      ) : null}
+      <TextInput
+        accessibilityLabel="Comment body"
+        autoFocus
+        maxLength={2000}
+        multiline
+        onChangeText={onChangeText}
+        placeholder="Add a comment..."
+        placeholderTextColor={tokens.colors.textTertiary}
+        style={[
+          styles.composerInput,
+          {
+            color: tokens.colors.textPrimary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+        value={text}
+      />
+      {error ? (
+        <Text
+          style={{
+            color: tokens.colors.danger,
+            fontFamily: tokens.typography.sans,
+            fontSize: 12,
+            fontWeight: "500",
+          }}
+        >
+          {error}
+        </Text>
+      ) : null}
+      <View style={styles.composerActions}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={onCancel}
+          style={({ pressed }) => [
+            styles.composerCancel,
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text
+            style={{
+              color: tokens.colors.textSecondary,
+              fontFamily: tokens.typography.sans,
+              fontSize: 12,
+              fontWeight: "700",
+            }}
+          >
+            Cancel
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          disabled={!canPost}
+          onPress={onSubmit}
+          style={({ pressed }) => [
+            styles.composerSubmit,
+            {
+              backgroundColor: canPost
+                ? tokens.colors.accent
+                : tokens.colors.accentSoft,
+              borderRadius: tokens.radius.sm,
+            },
+            pressed && canPost && styles.pressed,
+          ]}
+        >
+          <Text
+            style={{
+              color: canPost
+                ? tokens.colors.textInverse
+                : tokens.colors.textTertiary,
+              fontFamily: tokens.typography.sans,
+              fontSize: 13,
+              fontWeight: "700",
+            }}
+          >
+            Post
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function CommentBranch({
+  comment,
+  editTarget,
+  highlightedCommentId,
+  pendingChildren,
+  onCancelEdit,
+  onDismissFailed,
+  onOpenMenu,
+  onRegisterRef,
+  onReplyToRoot,
+  onRetry,
+  onSaveEdit,
+}: {
+  comment: MobileCommunityRoomThreadComment;
+  editTarget: EditTarget | null;
+  highlightedCommentId: string | null;
+  pendingChildren: PendingComment[];
+  onCancelEdit: () => void;
+  onDismissFailed: (localId: string) => void;
+  onOpenMenu: (
+    comment:
+      | MobileCommunityRoomThreadComment
+      | MobileCommunityRoomThreadChildComment,
+  ) => void;
+  onRegisterRef: (id: string, node: View | null) => void;
+  onReplyToRoot: (rootId: string, authorName: string) => void;
+  onRetry: (entry: PendingComment) => void;
+  onSaveEdit: (commentId: string, body: string) => void;
+}) {
+  const rootAuthorName =
+    comment.author.fullName || `@${comment.author.username}`;
+  const hasReplies = comment.replies.length > 0 || pendingChildren.length > 0;
+  const editingRoot =
+    editTarget?.kind === "comment" && editTarget.id === comment.id;
+
+  return (
+    <View style={styles.branch}>
+      {editingRoot ? (
+        <CommentEditCard
+          initialBody={editTarget.body}
+          onCancel={onCancelEdit}
+          onSave={(body) => onSaveEdit(comment.id, body)}
+        />
+      ) : (
+        <CommentRow
+          comment={comment}
+          isHighlighted={highlightedCommentId === comment.id}
+          onOpenMenu={() => onOpenMenu(comment)}
+          onRegisterRef={onRegisterRef}
+          onReply={() => onReplyToRoot(comment.id, rootAuthorName)}
+        />
+      )}
+      {hasReplies ? (
+        <ChildRail>
+          {comment.replies.map((reply) => {
+            const editingReply =
+              editTarget?.kind === "comment" && editTarget.id === reply.id;
+            if (editingReply) {
+              return (
+                <CommentEditCard
+                  key={reply.id}
+                  initialBody={editTarget.body}
+                  onCancel={onCancelEdit}
+                  onSave={(body) => onSaveEdit(reply.id, body)}
+                />
+              );
+            }
+            return (
+              <ChildCommentRow
+                key={reply.id}
+                comment={reply}
+                isHighlighted={highlightedCommentId === reply.id}
+                onOpenMenu={() => onOpenMenu(reply)}
+                onRegisterRef={onRegisterRef}
+                onReply={() =>
+                  onReplyToRoot(
+                    comment.id,
+                    reply.author.fullName || `@${reply.author.username}`,
+                  )
+                }
+              />
+            );
+          })}
+          {pendingChildren.map((entry) => (
+            <PendingRow
+              key={entry.localId}
+              entry={entry}
+              onDismiss={() => onDismissFailed(entry.localId)}
+              onRetry={() => onRetry(entry)}
+            />
+          ))}
+        </ChildRail>
+      ) : null}
+    </View>
+  );
+}
+
+function ChildRail({ children }: { children: React.ReactNode }) {
+  const { tokens } = useAppTheme();
+  return (
+    <View style={styles.childRailWrap}>
+      <View
+        style={[
+          styles.childRailLine,
+          { backgroundColor: tokens.colors.divider },
+        ]}
+      />
+      <View style={styles.childRailContent}>{children}</View>
+    </View>
+  );
+}
+
+function CommentRow({
+  comment,
+  isHighlighted,
+  onOpenMenu,
+  onRegisterRef,
+  onReply,
+}: {
+  comment: MobileCommunityRoomThreadComment;
+  isHighlighted: boolean;
+  onOpenMenu: () => void;
+  onRegisterRef: (id: string, node: View | null) => void;
+  onReply: () => void;
+}) {
+  return (
+    <CommentBody
+      authorName={comment.author.fullName || `@${comment.author.username}`}
+      avatarUrl={comment.author.avatarUrl}
+      body={comment.body}
+      commentId={comment.id}
+      createdAt={comment.createdAt}
+      editedAt={comment.editedAt}
+      isAuthor={comment.isAuthor}
+      isDeleted={comment.isDeleted}
+      isHighlighted={isHighlighted}
+      isOp={comment.isOp}
+      onOpenMenu={onOpenMenu}
+      onRegisterRef={onRegisterRef}
+      onReply={onReply}
+    />
+  );
+}
+
+function ChildCommentRow({
+  comment,
+  isHighlighted,
+  onOpenMenu,
+  onRegisterRef,
+  onReply,
+}: {
+  comment: MobileCommunityRoomThreadChildComment;
+  isHighlighted: boolean;
+  onOpenMenu: () => void;
+  onRegisterRef: (id: string, node: View | null) => void;
+  onReply: () => void;
+}) {
+  return (
+    <CommentBody
+      authorName={comment.author.fullName || `@${comment.author.username}`}
+      avatarUrl={comment.author.avatarUrl}
+      body={comment.body}
+      commentId={comment.id}
+      createdAt={comment.createdAt}
+      editedAt={comment.editedAt}
+      isAuthor={comment.isAuthor}
+      isDeleted={comment.isDeleted}
+      isHighlighted={isHighlighted}
+      isOp={comment.isOp}
+      onOpenMenu={onOpenMenu}
+      onRegisterRef={onRegisterRef}
+      onReply={onReply}
+    />
+  );
+}
+
+function CommentBody({
+  authorName,
+  avatarUrl,
+  body,
+  commentId,
+  createdAt,
+  editedAt,
+  isAuthor,
+  isDeleted,
+  isHighlighted,
+  isOp,
+  onOpenMenu,
+  onRegisterRef,
+  onReply,
+}: {
+  authorName: string;
+  avatarUrl: string | null;
+  body: string;
+  commentId: string;
+  createdAt: string;
+  editedAt: string | null;
+  isAuthor: boolean;
+  isDeleted: boolean;
+  isHighlighted: boolean;
+  isOp: boolean;
+  onOpenMenu: () => void;
+  onRegisterRef: (id: string, node: View | null) => void;
+  onReply: () => void;
+}) {
+  const { tokens } = useAppTheme();
+
+  return (
+    <View
+      ref={(node) => onRegisterRef(commentId, node)}
+      style={[
+        styles.commentRow,
+        isHighlighted && {
+          backgroundColor: tokens.colors.accentSoft,
+          borderRadius: tokens.radius.sm,
+          padding: 6,
+          marginHorizontal: -6,
+        },
+      ]}
+    >
+      <Avatar
+        avatarUrl={isDeleted ? null : avatarUrl}
+        name={isDeleted ? "—" : authorName}
+        size={24}
+      />
+      <View style={styles.commentCopy}>
+        <View style={styles.commentHeader}>
+          <Text
+            numberOfLines={1}
+            style={{
+              color: isDeleted
+                ? tokens.colors.textTertiary
+                : tokens.colors.textPrimary,
+              fontFamily: tokens.typography.sans,
+              fontSize: 12,
+              fontStyle: isDeleted ? "italic" : "normal",
+              fontWeight: "700",
+            }}
+          >
+            {isDeleted ? "[deleted]" : `${authorName}${isAuthor ? " · you" : ""}`}
+          </Text>
+          {!isDeleted && isOp ? (
+            <View
+              style={[
+                styles.opBadge,
+                {
+                  backgroundColor: tokens.colors.accentSoft,
+                  borderRadius: tokens.radius.xs,
+                },
+              ]}
+            >
+              <Text
+                style={{
+                  color: tokens.colors.accent,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 9,
+                  fontWeight: "700",
+                  letterSpacing: 0.6,
+                }}
+              >
+                OP
+              </Text>
+            </View>
+          ) : null}
+          <Text
+            style={{
+              color: tokens.colors.textTertiary,
+              fontFamily: tokens.typography.sans,
+              fontSize: 11,
+              fontWeight: "500",
+              marginLeft: "auto",
+            }}
+          >
+            {formatRelative(createdAt)}
+          </Text>
+        </View>
+        <Text
+          style={[
+            styles.commentBodyText,
+            {
+              color: isDeleted
+                ? tokens.colors.textTertiary
+                : tokens.colors.textSecondary,
+              fontFamily: tokens.typography.sans,
+              fontStyle: isDeleted ? "italic" : "normal",
+            },
+          ]}
+        >
+          {body}
+          {!isDeleted && editedAt ? (
+            <Text
+              style={{
+                color: tokens.colors.textTertiary,
+                fontFamily: tokens.typography.sans,
+                fontSize: 11,
+                fontWeight: "500",
+              }}
+            >
+              {"  "}(edited)
+            </Text>
+          ) : null}
+        </Text>
+        {!isDeleted ? (
+          <View style={styles.commentActionsRow}>
+            <Pressable
+              accessibilityRole="button"
+              onPress={onReply}
+              style={({ pressed }) => [pressed && styles.pressed]}
+            >
+              <Text
+                style={[
+                  styles.replyLink,
+                  {
+                    color: tokens.colors.textTertiary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                Reply
+              </Text>
+            </Pressable>
+            <OverflowButton onPress={onOpenMenu} compact />
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function PendingRow({
+  entry,
+  onDismiss,
+  onRetry,
+}: {
+  entry: PendingComment;
+  onDismiss: () => void;
+  onRetry: () => void;
+}) {
+  const { tokens } = useAppTheme();
+  const failed = entry.status === "failed";
+
+  return (
+    <View style={[styles.commentRow, { opacity: failed ? 1 : 0.55 }]}>
+      <Avatar avatarUrl={null} name="You" size={24} />
+      <View style={styles.commentCopy}>
+        <View style={styles.commentHeader}>
+          <Text
+            style={{
+              color: tokens.colors.textPrimary,
+              fontFamily: tokens.typography.sans,
+              fontSize: 12,
+              fontWeight: "700",
+            }}
+          >
+            You
+          </Text>
+          <Text
+            style={{
+              color: tokens.colors.textTertiary,
+              fontFamily: tokens.typography.sans,
+              fontSize: 11,
+              fontWeight: "500",
+              marginLeft: "auto",
+            }}
+          >
+            {failed ? "Failed" : "Posting…"}
+          </Text>
+        </View>
+        <Text
+          style={[
+            styles.commentBodyText,
+            {
+              color: tokens.colors.textSecondary,
+              fontFamily: tokens.typography.sans,
+            },
+          ]}
+        >
+          {entry.body}
+        </Text>
+        {failed ? (
+          <View style={styles.pendingActions}>
+            <Pressable
+              accessibilityRole="button"
+              onPress={onRetry}
+              style={({ pressed }) => [pressed && styles.pressed]}
+            >
+              <Text
+                style={{
+                  color: tokens.colors.accent,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 12,
+                  fontWeight: "700",
+                }}
+              >
+                Retry
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              onPress={onDismiss}
+              style={({ pressed }) => [pressed && styles.pressed]}
+            >
+              <Text
+                style={{
+                  color: tokens.colors.textTertiary,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 12,
+                  fontWeight: "700",
+                }}
+              >
+                Dismiss
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function ThreadByline({
+  thread,
+}: {
+  thread: MobileCommunityRoomThreadDetail["thread"];
+}) {
+  const { tokens } = useAppTheme();
+  const authorName = thread.author.fullName || `@${thread.author.username}`;
+  const youSuffix = thread.isAuthor ? " · you" : "";
+  const relative = formatRelative(thread.createdAt);
+
+  return (
+    <View style={styles.byline}>
+      <Avatar
+        avatarUrl={thread.author.avatarUrl}
+        name={authorName}
+        size={24}
+      />
+      <Text
+        numberOfLines={1}
+        style={[
+          styles.bylineText,
+          {
+            color: tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {authorName}
+        {youSuffix} · {relative}
+      </Text>
+    </View>
+  );
+}
+
+function OverflowButton({
+  compact,
+  onPress,
+}: {
+  compact?: boolean;
+  onPress: () => void;
+}) {
+  const { tokens } = useAppTheme();
+  return (
+    <Pressable
+      accessibilityLabel="More actions"
+      accessibilityRole="button"
+      hitSlop={8}
+      onPress={onPress}
+      style={({ pressed }) => [
+        compact ? styles.overflowCompact : styles.overflow,
+        pressed && styles.pressed,
+      ]}
+    >
+      <Text
+        style={{
+          color: tokens.colors.textTertiary,
+          fontFamily: tokens.typography.sans,
+          fontSize: compact ? 14 : 16,
+          fontWeight: "700",
+          letterSpacing: 1,
+        }}
+      >
+        •••
+      </Text>
+    </Pressable>
+  );
+}
+
+function SortToggle({
+  onChange,
+  sort,
+}: {
+  onChange: (next: MobileCommunityRoomCommentSort) => void;
+  sort: MobileCommunityRoomCommentSort;
+}) {
+  const { tokens } = useAppTheme();
+
+  const pill = (value: MobileCommunityRoomCommentSort, label: string) => {
+    const active = sort === value;
+    return (
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ selected: active }}
+        onPress={() => onChange(value)}
+        style={({ pressed }) => [
+          styles.sortPill,
+          {
+            backgroundColor: active
+              ? tokens.colors.pillActive
+              : tokens.colors.surface,
+            borderColor: active ? tokens.colors.pillActive : tokens.colors.border,
+            borderRadius: tokens.radius.xs,
+          },
+          pressed && styles.pressed,
+        ]}
+      >
+        <Text
+          style={{
+            color: active
+              ? tokens.colors.pillActiveText
+              : tokens.colors.textSecondary,
+            fontFamily: tokens.typography.sans,
+            fontSize: 11,
+            fontWeight: "700",
+            letterSpacing: 0.2,
+          }}
+        >
+          {label}
+        </Text>
+      </Pressable>
+    );
+  };
+
+  return (
+    <View style={styles.sortRow}>
+      {pill("newest", "Newest")}
+      {pill("oldest", "Oldest")}
+    </View>
+  );
+}
+
+function ThreadEditCard({
+  initialBody,
+  initialTitle,
+  onCancel,
+  onSave,
+}: {
+  initialBody: string;
+  initialTitle: string;
+  onCancel: () => void;
+  onSave: (title: string, body: string) => void;
+}) {
+  const { tokens } = useAppTheme();
+  const [title, setTitle] = useState(initialTitle);
+  const [body, setBody] = useState(initialBody);
+  const canSave =
+    title.trim().length > 0 &&
+    body.trim().length > 0 &&
+    (title.trim() !== initialTitle.trim() ||
+      body.trim() !== initialBody.trim());
+
+  return (
+    <View
+      style={[
+        styles.editCard,
+        {
+          backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
+          borderRadius: tokens.radius.sm,
+        },
+      ]}
+    >
+      <TextInput
+        accessibilityLabel="Thread title"
+        maxLength={200}
+        onChangeText={setTitle}
+        placeholder="Title"
+        placeholderTextColor={tokens.colors.textTertiary}
+        style={[
+          styles.editTitleInput,
+          {
+            color: tokens.colors.textPrimary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+        value={title}
+      />
+      <TextInput
+        accessibilityLabel="Thread body"
+        maxLength={5000}
+        multiline
+        onChangeText={setBody}
+        placeholder="Body"
+        placeholderTextColor={tokens.colors.textTertiary}
+        style={[
+          styles.editBodyInput,
+          {
+            color: tokens.colors.textPrimary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+        value={body}
+      />
+      <EditFooter
+        canSave={canSave}
+        onCancel={onCancel}
+        onSave={() => onSave(title.trim(), body.trim())}
+      />
+    </View>
+  );
+}
+
+function CommentEditCard({
+  initialBody,
+  onCancel,
+  onSave,
+}: {
+  initialBody: string;
+  onCancel: () => void;
+  onSave: (body: string) => void;
+}) {
+  const { tokens } = useAppTheme();
+  const [body, setBody] = useState(initialBody);
+  const canSave =
+    body.trim().length > 0 && body.trim() !== initialBody.trim();
+
+  return (
+    <View
+      style={[
+        styles.editCard,
+        {
+          backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
+          borderRadius: tokens.radius.sm,
+        },
+      ]}
+    >
+      <TextInput
+        accessibilityLabel="Comment body"
+        autoFocus
+        maxLength={2000}
+        multiline
+        onChangeText={setBody}
+        placeholder="Edit comment"
+        placeholderTextColor={tokens.colors.textTertiary}
+        style={[
+          styles.composerInput,
+          {
+            color: tokens.colors.textPrimary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+        value={body}
+      />
+      <EditFooter
+        canSave={canSave}
+        onCancel={onCancel}
+        onSave={() => onSave(body.trim())}
+      />
+    </View>
+  );
+}
+
+function EditFooter({
+  canSave,
+  onCancel,
+  onSave,
+}: {
+  canSave: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+}) {
+  const { tokens } = useAppTheme();
+
+  return (
+    <View style={styles.composerActions}>
+      <Pressable
+        accessibilityRole="button"
+        onPress={onCancel}
+        style={({ pressed }) => [
+          styles.composerCancel,
+          pressed && styles.pressed,
+        ]}
+      >
+        <Text
+          style={{
+            color: tokens.colors.textSecondary,
+            fontFamily: tokens.typography.sans,
+            fontSize: 12,
+            fontWeight: "700",
+          }}
+        >
+          Cancel
+        </Text>
+      </Pressable>
+      <Pressable
+        accessibilityRole="button"
+        disabled={!canSave}
+        onPress={onSave}
+        style={({ pressed }) => [
+          styles.composerSubmit,
+          {
+            backgroundColor: canSave
+              ? tokens.colors.accent
+              : tokens.colors.accentSoft,
+            borderRadius: tokens.radius.sm,
+          },
+          pressed && canSave && styles.pressed,
+        ]}
+      >
+        <Text
+          style={{
+            color: canSave
+              ? tokens.colors.textInverse
+              : tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+            fontSize: 13,
+            fontWeight: "700",
+          }}
+        >
+          Save
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function Avatar({
+  avatarUrl,
+  name,
+  size,
+}: {
+  avatarUrl: string | null;
+  name: string;
+  size: number;
+}) {
+  const { tokens } = useAppTheme();
+
+  if (isSafeAvatarUrl(avatarUrl)) {
+    return (
+      <Image
+        source={{ uri: avatarUrl }}
+        style={{ width: size, height: size, borderRadius: size / 2 }}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={{
+        alignItems: "center",
+        backgroundColor: tokens.colors.surfaceMuted,
+        borderRadius: size / 2,
+        height: size,
+        justifyContent: "center",
+        width: size,
+      }}
+    >
+      <Text
+        style={{
+          color: tokens.colors.textPrimary,
+          fontFamily: tokens.typography.sans,
+          fontSize: size < 28 ? 10 : 12,
+          fontWeight: "700",
+        }}
+      >
+        {getInitials(name)}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    fontSize: 15,
+    fontWeight: "500",
+    lineHeight: 22,
+  },
+  branch: {
+    gap: 8,
+  },
+  byline: {
+    alignItems: "center",
+    flex: 1,
+    flexDirection: "row",
+    gap: 8,
+  },
+  bylineRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 8,
+  },
+  bylineText: {
+    flex: 1,
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: -0.05,
+  },
+  childRailContent: {
+    flex: 1,
+    gap: 12,
+  },
+  childRailLine: {
+    width: 1,
+  },
+  childRailWrap: {
+    flexDirection: "row",
+    gap: 13,
+    paddingLeft: 4,
+  },
+  commentBodyText: {
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+  },
+  commentCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  commentHeader: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 6,
+  },
+  commentActionsRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 14,
+    paddingTop: 2,
+  },
+  commentRow: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    gap: 10,
+  },
+  commentsHeader: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "space-between",
+    paddingTop: 4,
+  },
+  commentsLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+  },
+  editBodyInput: {
+    fontSize: 14,
+    fontWeight: "500",
+    lineHeight: 20,
+    minHeight: 96,
+    textAlignVertical: "top",
+  },
+  editCard: {
+    borderWidth: 1,
+    gap: 10,
+    padding: 12,
+  },
+  editTitleInput: {
+    fontSize: 16,
+    fontWeight: "700",
+    letterSpacing: -0.2,
+    lineHeight: 20,
+  },
+  composerActions: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "flex-end",
+  },
+  composerActive: {
+    borderWidth: 1,
+    gap: 10,
+    padding: 10,
+  },
+  composerCancel: {
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  composerCollapsed: {
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 36,
+    paddingHorizontal: 12,
+  },
+  composerCollapsedText: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  composerInput: {
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+    minHeight: 56,
+    textAlignVertical: "top",
+  },
+  composerSubmit: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 30,
+    paddingHorizontal: 14,
+  },
+  divider: {
+    height: 1,
+    width: "100%",
+  },
+  emptyHint: {
+    fontSize: 12,
+    fontStyle: "italic",
+    fontWeight: "500",
+    paddingTop: 4,
+  },
+  opBadge: {
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  pendingActions: {
+    flexDirection: "row",
+    gap: 14,
+  },
+  overflow: {
+    alignItems: "center",
+    height: 28,
+    justifyContent: "center",
+    width: 28,
+  },
+  overflowCompact: {
+    alignItems: "center",
+    height: 22,
+    justifyContent: "center",
+    width: 22,
+  },
+  pressed: {
+    opacity: 0.82,
+  },
+  sortPill: {
+    alignItems: "center",
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 22,
+    paddingHorizontal: 10,
+  },
+  sortRow: {
+    flexDirection: "row",
+    gap: 6,
+  },
+  replyBanner: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+  },
+  replyLink: {
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: -0.05,
+  },
+  retryButton: {
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  stack: {
+    gap: 12,
+  },
+});

--- a/apps/mobile/app/event/[id]/threads/[threadId].tsx
+++ b/apps/mobile/app/event/[id]/threads/[threadId].tsx
@@ -41,10 +41,13 @@ import {
   createMobileEventThreadComment,
   deleteMobileEventThread,
   deleteMobileEventThreadComment,
+  loadMobileEventThreadComment,
+  loadMobileEventThreadComments,
   loadMobileEventThread,
   updateMobileEventThread,
   updateMobileEventThreadComment,
 } from "../../../../src/lib/mobileApi";
+import { supabase } from "../../../../src/lib/supabase";
 import { useAppTheme } from "../../../../src/providers/ThemeProvider";
 
 type MenuTarget =
@@ -133,6 +136,143 @@ function findCommentById(
   return null;
 }
 
+function countRenderedComments(
+  comments: MobileCommunityRoomThreadComment[],
+): number {
+  return comments.reduce(
+    (total, comment) => total + 1 + comment.replies.length,
+    0,
+  );
+}
+
+function hasCommentInTree(
+  comments: MobileCommunityRoomThreadComment[],
+  commentId: string,
+): boolean {
+  return findCommentById(comments, commentId) !== null;
+}
+
+function sortRootComments(
+  comments: MobileCommunityRoomThreadComment[],
+  sort: MobileCommunityRoomCommentSort,
+): MobileCommunityRoomThreadComment[] {
+  const direction = sort === "newest" ? -1 : 1;
+  return [...comments].sort(
+    (a, b) =>
+      direction *
+        (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) ||
+      direction * a.id.localeCompare(b.id),
+  );
+}
+
+function sortReplies(
+  replies: MobileCommunityRoomThreadChildComment[],
+): MobileCommunityRoomThreadChildComment[] {
+  return [...replies].sort(
+    (a, b) =>
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime() ||
+      a.id.localeCompare(b.id),
+  );
+}
+
+function mergeCommentIntoTree(
+  comments: MobileCommunityRoomThreadComment[],
+  incoming: MobileCommunityRoomThreadComment,
+  sort: MobileCommunityRoomCommentSort,
+): {
+  comments: MobileCommunityRoomThreadComment[];
+  inserted: boolean;
+  rendered: boolean;
+} {
+  if (incoming.parentId) {
+    let inserted = false;
+    let rendered = false;
+    const next = comments.map((comment) => {
+      if (comment.id !== incoming.parentId) return comment;
+      rendered = true;
+      const child: MobileCommunityRoomThreadChildComment = {
+        id: incoming.id,
+        threadId: incoming.threadId,
+        parentId: incoming.parentId,
+        body: incoming.body,
+        createdAt: incoming.createdAt,
+        author: incoming.author,
+        isAuthor: incoming.isAuthor,
+        isOp: incoming.isOp,
+        isDeleted: incoming.isDeleted,
+        editedAt: incoming.editedAt,
+      };
+      const existed = comment.replies.some((reply) => reply.id === child.id);
+      inserted = !existed;
+      return {
+        ...comment,
+        replies: sortReplies([
+          ...comment.replies.filter((reply) => reply.id !== child.id),
+          child,
+        ]),
+      };
+    });
+    return { comments: next, inserted, rendered };
+  }
+
+  const existed = comments.some((comment) => comment.id === incoming.id);
+  const next = sortRootComments(
+    [...comments.filter((comment) => comment.id !== incoming.id), incoming],
+    sort,
+  );
+  return { comments: next, inserted: !existed, rendered: true };
+}
+
+function mergeCommentPageIntoTree(
+  current: MobileCommunityRoomThreadComment[],
+  incoming: MobileCommunityRoomThreadComment[],
+  sort: MobileCommunityRoomCommentSort,
+): MobileCommunityRoomThreadComment[] {
+  return incoming.reduce(
+    (comments, comment) => {
+      const mergedRoot = mergeCommentIntoTree(comments, comment, sort).comments;
+      return comment.replies.reduce((withReplies, reply) => {
+        const replyAsComment: MobileCommunityRoomThreadComment = {
+          ...reply,
+          replies: [],
+        };
+        return mergeCommentIntoTree(withReplies, replyAsComment, sort).comments;
+      }, mergedRoot);
+    },
+    current,
+  );
+}
+
+function removeCommentFromTree(
+  comments: MobileCommunityRoomThreadComment[],
+  commentId: string,
+): {
+  comments: MobileCommunityRoomThreadComment[];
+  removed: boolean;
+} {
+  let removed = false;
+  const roots = comments.filter((comment) => {
+    if (comment.id === commentId) {
+      removed = true;
+      return false;
+    }
+    return true;
+  });
+  const next = roots.map((comment) => {
+    const replies = comment.replies.filter((reply) => {
+      if (reply.id === commentId) {
+        removed = true;
+        return false;
+      }
+      return true;
+    });
+    return replies.length === comment.replies.length
+      ? comment
+      : { ...comment, replies };
+  });
+  return { comments: next, removed };
+}
+
 function buildMenuOptions(target: MenuTarget): ThreadActionOption[] {
   const options: ThreadActionOption[] = [];
   if (target.isAuthor) {
@@ -170,6 +310,7 @@ export default function EventThreadDetailScreen() {
     null,
   );
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [replyText, setReplyText] = useState("");
   const [replyError, setReplyError] = useState<string | null>(null);
@@ -231,12 +372,30 @@ export default function EventThreadDetailScreen() {
     async (body: string, parentRootId: string | null, localId: string) => {
       if (!eventId || !threadId) return;
       try {
-        await createMobileEventThreadComment(eventId, threadId, {
+        const comment = await createMobileEventThreadComment(eventId, threadId, {
           body,
           parentCommentId: parentRootId,
         });
         setPending((prev) => prev.filter((entry) => entry.localId !== localId));
-        await load();
+        setDetail((current) => {
+          if (!current) return current;
+          const merged = mergeCommentIntoTree(current.comments, comment, sort);
+          return {
+            ...current,
+            thread: {
+              ...current.thread,
+              commentCount: merged.inserted
+                ? current.thread.commentCount + 1
+                : current.thread.commentCount,
+            },
+            comments: merged.comments,
+            commentPage: {
+              ...current.commentPage,
+              comments: merged.comments,
+              loadedCount: countRenderedComments(merged.comments),
+            },
+          };
+        });
       } catch (nextError) {
         console.warn("createMobileEventThreadComment failed", nextError);
         setReplyError("Couldn't post your reply. Try again.");
@@ -247,7 +406,7 @@ export default function EventThreadDetailScreen() {
         );
       }
     },
-    [eventId, threadId, load],
+    [eventId, threadId, sort],
   );
 
   const handlePostReply = async () => {
@@ -376,6 +535,146 @@ export default function EventThreadDetailScreen() {
     if (next === sort) return;
     setSort(next);
   };
+
+  const handleLoadMore = async () => {
+    if (!detail || !eventId || !threadId || loadingMore) return;
+    const cursor = detail.commentPage.nextCursor;
+    if (!cursor) return;
+
+    setLoadingMore(true);
+    try {
+      const page = await loadMobileEventThreadComments(eventId, threadId, {
+        cursor,
+        sort,
+      });
+      setDetail((current) => {
+        if (!current) return current;
+        const comments = mergeCommentPageIntoTree(
+          current.comments,
+          page.comments,
+          sort,
+        );
+        return {
+          ...current,
+          comments,
+          commentPage: {
+            ...page,
+            comments,
+            loadedCount: countRenderedComments(comments),
+          },
+        };
+      });
+    } catch (nextError) {
+      console.warn("loadMobileEventThreadComments failed", nextError);
+      Alert.alert("Couldn't load more", "Pull to refresh or try again.");
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!eventId || !threadId) return;
+    let disposed = false;
+    const channel = supabase
+      .channel(`event-thread-comments:${threadId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "event_room_thread_comments",
+          filter: `thread_id=eq.${threadId}`,
+        },
+        async (payload) => {
+          const eventType = payload.eventType;
+          const rawNew = payload.new as { id?: unknown } | null;
+          const rawOld = payload.old as { id?: unknown } | null;
+          const commentId =
+            typeof rawNew?.id === "string"
+              ? rawNew.id
+              : typeof rawOld?.id === "string"
+                ? rawOld.id
+                : null;
+          if (!commentId || disposed) return;
+
+          if (eventType === "DELETE") {
+            setDetail((current) => {
+              if (!current) return current;
+              const removed = removeCommentFromTree(current.comments, commentId);
+              if (!removed.removed) return current;
+              return {
+                ...current,
+                thread: {
+                  ...current.thread,
+                  commentCount: Math.max(0, current.thread.commentCount - 1),
+                },
+                comments: removed.comments,
+                commentPage: {
+                  ...current.commentPage,
+                  comments: removed.comments,
+                  loadedCount: countRenderedComments(removed.comments),
+                },
+              };
+            });
+            return;
+          }
+
+          try {
+            const comment = await loadMobileEventThreadComment(
+              eventId,
+              threadId,
+              commentId,
+            );
+            if (disposed) return;
+            setPending((current) =>
+              current.filter(
+                (entry) =>
+                  !(
+                    entry.body === comment.body &&
+                    entry.parentRootId === comment.parentId
+                  ),
+              ),
+            );
+            setDetail((current) => {
+              if (!current) return current;
+              const alreadyHadComment = hasCommentInTree(
+                current.comments,
+                comment.id,
+              );
+              const merged = mergeCommentIntoTree(
+                current.comments,
+                comment,
+                sort,
+              );
+              return {
+                ...current,
+                thread: {
+                  ...current.thread,
+                  commentCount:
+                    eventType === "INSERT" && !alreadyHadComment
+                      ? current.thread.commentCount + 1
+                      : current.thread.commentCount,
+                },
+                comments: merged.comments,
+                commentPage: {
+                  ...current.commentPage,
+                  comments: merged.comments,
+                  loadedCount: countRenderedComments(merged.comments),
+                },
+              };
+            });
+          } catch (nextError) {
+            console.warn("Realtime comment refresh failed", nextError);
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      disposed = true;
+      void supabase.removeChannel(channel);
+    };
+  }, [eventId, threadId, sort]);
 
   const handleOpenThreadMenu = () => {
     if (!detail) return;
@@ -704,6 +1003,39 @@ export default function EventThreadDetailScreen() {
               onSaveEdit={handleSaveCommentEdit}
             />
           ))}
+
+          {detail.thread.commentCount > countRenderedComments(detail.comments) ? (
+            <Pressable
+              accessibilityRole="button"
+              disabled={loadingMore || !detail.commentPage.nextCursor}
+              onPress={() => void handleLoadMore()}
+              style={({ pressed }) => [
+                styles.loadMoreButton,
+                {
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                  opacity:
+                    loadingMore || !detail.commentPage.nextCursor ? 0.55 : 1,
+                },
+                pressed && styles.pressed,
+              ]}
+            >
+              {loadingMore ? (
+                <ActivityIndicator color={tokens.colors.textSecondary} />
+              ) : null}
+              <Text
+                style={{
+                  color: tokens.colors.textPrimary,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 13,
+                  fontWeight: "700",
+                }}
+              >
+                Load more
+              </Text>
+            </Pressable>
+          ) : null}
 
           {topLevelPending.map((entry) => (
             <PendingRow
@@ -1793,6 +2125,15 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     letterSpacing: -0.2,
     lineHeight: 20,
+  },
+  loadMoreButton: {
+    alignItems: "center",
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 8,
+    justifyContent: "center",
+    minHeight: 40,
+    paddingHorizontal: 14,
   },
   composerActions: {
     alignItems: "center",

--- a/apps/mobile/app/event/[id]/threads/index.tsx
+++ b/apps/mobile/app/event/[id]/threads/index.tsx
@@ -1,0 +1,510 @@
+import type {
+  MobileCommunityRoomThread,
+  MobileCommunityRoomThreadList,
+} from "@kurecal/domain";
+import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
+import { useCallback, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import {
+  HeaderActionButton,
+  MobilePage,
+} from "../../../../src/components/chrome/MobilePage";
+import { ScreenState } from "../../../../src/components/chrome/ScreenState";
+import { loadMobileEventThreads } from "../../../../src/lib/mobileApi";
+import { useAppTheme } from "../../../../src/providers/ThemeProvider";
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function formatRelative(value: string): string {
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return "Recently";
+  const diff = Date.now() - ts;
+  const minutes = Math.max(1, Math.round(diff / 60_000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatReplyLabel(count: number): string {
+  if (count === 0) return "No replies";
+  if (count === 1) return "1 reply";
+  return `${count} replies`;
+}
+
+export default function EventThreadsScreen() {
+  const { tokens } = useAppTheme();
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const eventId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const [threads, setThreads] = useState<MobileCommunityRoomThread[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestSequenceRef = useRef(0);
+
+  const loadPage = useCallback(
+    async (mode: "initial" | "more") => {
+      if (!eventId) {
+        setError("Event id is missing");
+        setLoading(false);
+        return;
+      }
+
+      const requestId = ++requestSequenceRef.current;
+      if (mode === "initial") {
+        setLoading(true);
+      } else {
+        setLoadingMore(true);
+      }
+
+      try {
+        const cursor = mode === "more" ? nextCursor : null;
+        const data: MobileCommunityRoomThreadList = await loadMobileEventThreads(
+          eventId,
+          cursor,
+        );
+        if (requestId !== requestSequenceRef.current) return;
+        setThreads((existing) =>
+          mode === "more" ? [...existing, ...data.threads] : data.threads,
+        );
+        setNextCursor(data.nextCursor);
+        setError(null);
+      } catch (nextError) {
+        if (requestId !== requestSequenceRef.current) return;
+        setError(
+          nextError instanceof Error
+            ? nextError.message
+            : "Unable to load threads",
+        );
+      } finally {
+        if (requestId === requestSequenceRef.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
+      }
+    },
+    [eventId, nextCursor],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadPage("initial");
+      // We intentionally don't depend on loadPage (which depends on nextCursor)
+      // because focus refresh should reset to the first page.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [eventId]),
+  );
+
+  const openThread = (threadId: string) => {
+    if (!eventId) return;
+    router.push(`/event/${eventId}/threads/${threadId}`);
+  };
+
+  const openComposer = () => {
+    if (!eventId) return;
+    router.push(`/event/${eventId}/threads/new`);
+  };
+
+  return (
+    <MobilePage
+      title="Threads"
+      action={
+        <HeaderActionButton label="Back" onPress={() => router.back()} />
+      }
+    >
+      {loading && threads.length === 0 ? (
+        <ScreenState
+          mode="loading"
+          title="Loading threads"
+          description="Pulling the latest discussions for this event."
+        />
+      ) : null}
+
+      {error && threads.length === 0 ? (
+        <ScreenState
+          mode="error"
+          title="Threads unavailable"
+          description={error}
+          action={
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => void loadPage("initial")}
+              style={({ pressed }) => [
+                styles.retryButton,
+                {
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                },
+                pressed && styles.pressed,
+              ]}
+            >
+              <Text
+                style={{
+                  color: tokens.colors.textPrimary,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 13,
+                  fontWeight: "700",
+                }}
+              >
+                Try again
+              </Text>
+            </Pressable>
+          }
+        />
+      ) : null}
+
+      {!loading || threads.length > 0 ? (
+        <View style={styles.stack}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={openComposer}
+            style={({ pressed }) => [
+              styles.startButton,
+              {
+                backgroundColor: tokens.colors.accent,
+                borderRadius: tokens.radius.sm,
+              },
+              pressed && styles.pressed,
+            ]}
+          >
+            <Text
+              style={{
+                color: tokens.colors.textInverse,
+                fontFamily: tokens.typography.sans,
+                fontSize: 13,
+                fontWeight: "700",
+              }}
+            >
+              Start a thread
+            </Text>
+          </Pressable>
+
+          {threads.length === 0 ? (
+            <View
+              style={[
+                styles.emptyState,
+                {
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.emptyTitle,
+                  {
+                    color: tokens.colors.textPrimary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                No threads yet
+              </Text>
+              <Text
+                style={[
+                  styles.emptyBody,
+                  {
+                    color: tokens.colors.textTertiary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                Start the first conversation about this event.
+              </Text>
+            </View>
+          ) : (
+            <View
+              style={[
+                styles.list,
+                {
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                },
+              ]}
+            >
+              {threads.map((thread, index) => (
+                <ThreadCard
+                  key={thread.id}
+                  thread={thread}
+                  isLast={index === threads.length - 1}
+                  onOpen={() => openThread(thread.id)}
+                />
+              ))}
+            </View>
+          )}
+
+          {nextCursor ? (
+            <Pressable
+              accessibilityRole="button"
+              disabled={loadingMore}
+              onPress={() => void loadPage("more")}
+              style={({ pressed }) => [
+                styles.loadMore,
+                {
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                },
+                pressed && styles.pressed,
+              ]}
+            >
+              {loadingMore ? (
+                <ActivityIndicator
+                  color={tokens.colors.textSecondary}
+                  size="small"
+                />
+              ) : (
+                <Text
+                  style={{
+                    color: tokens.colors.textSecondary,
+                    fontFamily: tokens.typography.sans,
+                    fontSize: 13,
+                    fontWeight: "700",
+                  }}
+                >
+                  Load more
+                </Text>
+              )}
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </MobilePage>
+  );
+}
+
+function ThreadCard({
+  isLast,
+  onOpen,
+  thread,
+}: {
+  isLast: boolean;
+  onOpen: () => void;
+  thread: MobileCommunityRoomThread;
+}) {
+  const { tokens } = useAppTheme();
+  const authorName = thread.author.fullName || `@${thread.author.username}`;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onOpen}
+      style={({ pressed }) => [
+        styles.card,
+        !isLast && {
+          borderBottomColor: tokens.colors.divider,
+          borderBottomWidth: 1,
+        },
+        pressed && { backgroundColor: tokens.colors.surfaceMuted },
+      ]}
+    >
+      <View style={styles.cardAuthorRow}>
+        <Avatar
+          avatarUrl={thread.author.avatarUrl}
+          name={authorName}
+          size={20}
+        />
+        <Text
+          numberOfLines={1}
+          style={{
+            color: tokens.colors.textSecondary,
+            flex: 1,
+            fontFamily: tokens.typography.sans,
+            fontSize: 12,
+            fontWeight: "600",
+          }}
+        >
+          {authorName}
+          {thread.isAuthor ? " · you" : ""}
+        </Text>
+        <Text
+          style={{
+            color: tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+            fontSize: 11,
+            fontWeight: "500",
+          }}
+        >
+          {formatRelative(thread.lastActivityAt)}
+        </Text>
+      </View>
+      <Text
+        numberOfLines={2}
+        style={[
+          styles.cardTitle,
+          {
+            color: tokens.colors.textPrimary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {thread.title}
+      </Text>
+      <Text
+        numberOfLines={2}
+        style={[
+          styles.cardBody,
+          {
+            color: tokens.colors.textSecondary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {thread.body}
+      </Text>
+      <Text
+        style={[
+          styles.cardMeta,
+          {
+            color: tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {formatReplyLabel(thread.commentCount)}
+      </Text>
+    </Pressable>
+  );
+}
+
+function isSafeAvatarUrl(url: string | null | undefined): url is string {
+  if (!url) return false;
+  return /^https?:\/\//i.test(url);
+}
+
+function Avatar({
+  avatarUrl,
+  name,
+  size,
+}: {
+  avatarUrl: string | null;
+  name: string;
+  size: number;
+}) {
+  const { tokens } = useAppTheme();
+
+  if (isSafeAvatarUrl(avatarUrl)) {
+    return (
+      <Image
+        source={{ uri: avatarUrl }}
+        style={{ width: size, height: size, borderRadius: size / 2 }}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={{
+        alignItems: "center",
+        backgroundColor: tokens.colors.surfaceMuted,
+        borderRadius: size / 2,
+        height: size,
+        justifyContent: "center",
+        width: size,
+      }}
+    >
+      <Text
+        style={{
+          color: tokens.colors.textPrimary,
+          fontFamily: tokens.typography.sans,
+          fontSize: size < 30 ? 10 : 12,
+          fontWeight: "700",
+        }}
+      >
+        {getInitials(name)}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  cardAuthorRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 8,
+  },
+  cardBody: {
+    fontSize: 12,
+    fontWeight: "500",
+    lineHeight: 16,
+  },
+  cardMeta: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.2,
+  },
+  cardTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    letterSpacing: -0.1,
+    lineHeight: 18,
+  },
+  emptyBody: {
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+  },
+  emptyState: {
+    alignItems: "center",
+    borderWidth: 1,
+    gap: 6,
+    padding: 16,
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    letterSpacing: -0.1,
+  },
+  list: {
+    borderWidth: 1,
+    overflow: "hidden",
+  },
+  loadMore: {
+    alignItems: "center",
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 34,
+    paddingHorizontal: 12,
+  },
+  pressed: {
+    opacity: 0.82,
+  },
+  retryButton: {
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  stack: {
+    gap: 10,
+  },
+  startButton: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 36,
+    paddingHorizontal: 12,
+  },
+});

--- a/apps/mobile/app/event/[id]/threads/new.tsx
+++ b/apps/mobile/app/event/[id]/threads/new.tsx
@@ -1,0 +1,234 @@
+import { router, useLocalSearchParams } from "expo-router";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import {
+  HeaderActionButton,
+  MobilePage,
+} from "../../../../src/components/chrome/MobilePage";
+import { createMobileCommunityRoomThread } from "../../../../src/lib/mobileApi";
+import { useAppTheme } from "../../../../src/providers/ThemeProvider";
+
+export default function NewEventThreadScreen() {
+  const { tokens } = useAppTheme();
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const eventId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [posting, setPosting] = useState(false);
+
+  const handlePost = async () => {
+    if (!eventId) {
+      setError("Event id is missing");
+      return;
+    }
+    const trimmedTitle = title.trim();
+    const trimmedBody = body.trim();
+    if (!trimmedTitle || !trimmedBody) {
+      setError("Add a title and a body to start the thread.");
+      return;
+    }
+
+    setError(null);
+    setPosting(true);
+    try {
+      const thread = await createMobileCommunityRoomThread(eventId, {
+        title: trimmedTitle,
+        body: trimmedBody,
+      });
+      router.replace(`/event/${eventId}/threads/${thread.id}`);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Couldn't post the thread.",
+      );
+      setPosting(false);
+    }
+  };
+
+  return (
+    <MobilePage
+      title="New thread"
+      action={
+        <HeaderActionButton
+          label="Cancel"
+          onPress={() => {
+            if (posting) return;
+            router.back();
+          }}
+        />
+      }
+    >
+      <View style={styles.stack}>
+        <View
+          style={[
+            styles.field,
+            {
+              backgroundColor: tokens.colors.surface,
+              borderColor: tokens.colors.border,
+              borderRadius: tokens.radius.sm,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.fieldLabel,
+              {
+                color: tokens.colors.textTertiary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+          >
+            Title
+          </Text>
+          <TextInput
+            accessibilityLabel="Thread title"
+            editable={!posting}
+            maxLength={200}
+            onChangeText={setTitle}
+            placeholder="What's this thread about?"
+            placeholderTextColor={tokens.colors.textTertiary}
+            style={[
+              styles.titleInput,
+              {
+                color: tokens.colors.textPrimary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+            value={title}
+          />
+        </View>
+
+        <View
+          style={[
+            styles.field,
+            {
+              backgroundColor: tokens.colors.surface,
+              borderColor: tokens.colors.border,
+              borderRadius: tokens.radius.sm,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.fieldLabel,
+              {
+                color: tokens.colors.textTertiary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+          >
+            Body
+          </Text>
+          <TextInput
+            accessibilityLabel="Thread body"
+            editable={!posting}
+            maxLength={5000}
+            multiline
+            onChangeText={setBody}
+            placeholder="Share context, ask a question, kick off a conversation..."
+            placeholderTextColor={tokens.colors.textTertiary}
+            style={[
+              styles.bodyInput,
+              {
+                color: tokens.colors.textPrimary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+            value={body}
+          />
+        </View>
+
+        {error ? (
+          <Text
+            style={{
+              color: tokens.colors.danger,
+              fontFamily: tokens.typography.sans,
+              fontSize: 13,
+              fontWeight: "500",
+            }}
+          >
+            {error}
+          </Text>
+        ) : null}
+
+        <Pressable
+          accessibilityRole="button"
+          disabled={posting}
+          onPress={handlePost}
+          style={({ pressed }) => [
+            styles.submit,
+            {
+              backgroundColor: tokens.colors.accent,
+              borderRadius: tokens.radius.sm,
+            },
+            pressed && styles.pressed,
+          ]}
+        >
+          {posting ? (
+            <ActivityIndicator color={tokens.colors.textInverse} />
+          ) : (
+            <Text
+              style={{
+                color: tokens.colors.textInverse,
+                fontFamily: tokens.typography.sans,
+                fontSize: 14,
+                fontWeight: "700",
+              }}
+            >
+              Post thread
+            </Text>
+          )}
+        </Pressable>
+      </View>
+    </MobilePage>
+  );
+}
+
+const styles = StyleSheet.create({
+  bodyInput: {
+    fontSize: 14,
+    fontWeight: "500",
+    lineHeight: 20,
+    minHeight: 160,
+    textAlignVertical: "top",
+  },
+  field: {
+    borderWidth: 1,
+    gap: 6,
+    padding: 12,
+  },
+  fieldLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+  },
+  pressed: {
+    opacity: 0.82,
+  },
+  stack: {
+    gap: 12,
+  },
+  submit: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 40,
+    paddingHorizontal: 12,
+  },
+  titleInput: {
+    fontSize: 16,
+    fontWeight: "700",
+    letterSpacing: -0.2,
+    lineHeight: 20,
+  },
+});

--- a/apps/mobile/src/components/chrome/MobilePage.tsx
+++ b/apps/mobile/src/components/chrome/MobilePage.tsx
@@ -3,6 +3,7 @@ import {
   useState,
   type PropsWithChildren,
   type ReactNode,
+  type RefObject,
 } from "react";
 import {
   type LayoutChangeEvent,
@@ -32,6 +33,7 @@ interface MobilePageProps extends PropsWithChildren {
   showAccentGlow?: boolean;
   footerInset?: number;
   contentStyle?: StyleProp<ViewStyle>;
+  scrollRef?: RefObject<ScrollView>;
 }
 
 export function MobilePage({
@@ -44,6 +46,7 @@ export function MobilePage({
   children,
   footerInset,
   contentStyle,
+  scrollRef,
 }: MobilePageProps) {
   const { tokens } = useAppTheme();
   const { handleScroll, isVisible } = useTabBarVisibility();
@@ -149,6 +152,7 @@ export function MobilePage({
         </View>
       ) : null}
       <ScrollView
+        ref={scrollRef}
         contentContainerStyle={[
           styles.content,
           {

--- a/apps/mobile/src/components/chrome/MobilePage.tsx
+++ b/apps/mobile/src/components/chrome/MobilePage.tsx
@@ -33,7 +33,7 @@ interface MobilePageProps extends PropsWithChildren {
   showAccentGlow?: boolean;
   footerInset?: number;
   contentStyle?: StyleProp<ViewStyle>;
-  scrollRef?: RefObject<ScrollView>;
+  scrollRef?: RefObject<ScrollView | null>;
 }
 
 export function MobilePage({

--- a/apps/mobile/src/components/community/CommunityRoomSheet.tsx
+++ b/apps/mobile/src/components/community/CommunityRoomSheet.tsx
@@ -1,0 +1,1182 @@
+import { FontAwesome } from "@expo/vector-icons";
+import type {
+  MobileCommunityRoomAttendee,
+  MobileCommunityRoomDetail,
+  MobileCommunityRoomRelationship,
+  MobileCommunityRoomSignal,
+} from "@kurecal/domain";
+import { router } from "expo-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  loadMobileCommunityRoom,
+  updateMobileEventEngagement,
+  updateMobileProfile,
+} from "../../lib/mobileApi";
+import { useAppTheme } from "../../providers/ThemeProvider";
+
+interface CommunityRoomSheetProps {
+  eventId: string | null;
+  onClose: () => void;
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function formatRelative(value: string): string {
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return "Recently";
+  const diff = Date.now() - ts;
+  const minutes = Math.max(1, Math.round(diff / 60_000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatEventTime(startTime: string): string {
+  const date = new Date(startTime);
+  if (Number.isNaN(date.getTime())) return startTime;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+const RELATIONSHIP_LABEL: Record<MobileCommunityRoomRelationship, string> = {
+  mutual: "Mutual",
+  follows_you: "Follows you",
+  in_network: "In network",
+  stranger: "",
+};
+
+function getViewerLabel(viewer: MobileCommunityRoomDetail["viewer"]): string {
+  if (viewer.isAttending && viewer.isVisible) return "You're going · Visible";
+  if (viewer.isAttending) return "You're going · Hidden";
+  if (viewer.isSaved) return "You saved this";
+  return "Not tracking";
+}
+
+function getSignalCopy(signal: MobileCommunityRoomSignal): string {
+  const name = signal.actor.fullName || `@${signal.actor.username}`;
+  switch (signal.kind) {
+    case "mutual_arrived":
+      return `${name} joined the room`;
+    case "saved":
+      return `${name} saved this event`;
+    case "joined_attending":
+    default:
+      return `${name} is going`;
+  }
+}
+
+export function CommunityRoomSheet({
+  eventId,
+  onClose,
+}: CommunityRoomSheetProps) {
+  const { tokens } = useAppTheme();
+  const [detail, setDetail] = useState<MobileCommunityRoomDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<
+    "going" | "save" | "visibility" | null
+  >(null);
+  const requestSequenceRef = useRef(0);
+  const visible = Boolean(eventId);
+
+  const load = useCallback(async (id: string) => {
+    const requestId = ++requestSequenceRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await loadMobileCommunityRoom(id);
+      if (requestId !== requestSequenceRef.current) return;
+      setDetail(next);
+    } catch (nextError) {
+      if (requestId !== requestSequenceRef.current) return;
+      setError(
+        nextError instanceof Error ? nextError.message : "Couldn't load room.",
+      );
+    } finally {
+      if (requestId === requestSequenceRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!eventId) {
+      setDetail(null);
+      setError(null);
+      return;
+    }
+    void load(eventId);
+  }, [eventId, load]);
+
+  const openProfile = (username: string) => {
+    onClose();
+    router.push(`/profile/${username}`);
+  };
+
+  const openFullEvent = () => {
+    if (!detail) return;
+    onClose();
+    router.push(`/event/${detail.event.id}`);
+  };
+
+  const handleToggleGoing = async () => {
+    if (!detail || pendingAction) return;
+    setPendingAction("going");
+    try {
+      await updateMobileEventEngagement(detail.event.id, {
+        status: detail.viewer.isAttending ? null : "attending",
+      });
+      await load(detail.event.id);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Couldn't update attendance.",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handleToggleSave = async () => {
+    if (!detail || pendingAction) return;
+    setPendingAction("save");
+    try {
+      await updateMobileEventEngagement(detail.event.id, {
+        isBookmarked: !detail.viewer.isSaved,
+      });
+      await load(detail.event.id);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error ? nextError.message : "Couldn't save event.",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const navigateToThreads = (mode: "list" | "new") => {
+    if (!detail) return;
+    onClose();
+    if (mode === "new") {
+      router.push(`/event/${detail.event.id}/threads/new`);
+    } else {
+      router.push(`/event/${detail.event.id}/threads`);
+    }
+  };
+
+  const handleGoVisible = async () => {
+    if (!detail || pendingAction) return;
+    setPendingAction("visibility");
+    try {
+      await updateMobileProfile({ showAttendance: true });
+      await load(detail.event.id);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Couldn't update visibility.",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      transparent
+      visible={visible}
+    >
+      <Pressable
+        accessibilityLabel="Close room"
+        style={[styles.overlay, { backgroundColor: tokens.colors.overlay }]}
+        onPress={onClose}
+      />
+      <SafeAreaView edges={["bottom"]} style={styles.safeArea}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: tokens.colors.shellElevated,
+              borderTopColor: tokens.colors.borderStrong,
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.dragHandle,
+              { backgroundColor: tokens.colors.borderStrong },
+            ]}
+          />
+
+          {loading && !detail ? (
+            <View style={styles.centered}>
+              <ActivityIndicator color={tokens.colors.accent} />
+            </View>
+          ) : null}
+
+          {error && !detail ? (
+            <View style={styles.centered}>
+              <Text
+                style={[
+                  styles.errorText,
+                  {
+                    color: tokens.colors.textSecondary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                {error}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => eventId && void load(eventId)}
+                style={[
+                  styles.retryButton,
+                  {
+                    borderColor: tokens.colors.border,
+                    borderRadius: tokens.radius.sm,
+                  },
+                ]}
+              >
+                <Text
+                  style={{
+                    color: tokens.colors.textPrimary,
+                    fontFamily: tokens.typography.sans,
+                    fontSize: 13,
+                    fontWeight: "700",
+                  }}
+                >
+                  Try again
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
+
+          {detail ? (
+            <ScrollView
+              contentContainerStyle={styles.content}
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.headerRow}>
+                <View style={styles.headerCopy}>
+                  <Text
+                    numberOfLines={2}
+                    style={[
+                      styles.title,
+                      {
+                        color: tokens.colors.textPrimary,
+                        fontFamily: tokens.typography.sans,
+                      },
+                    ]}
+                  >
+                    {detail.event.title}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.subMeta,
+                      {
+                        color: tokens.colors.textTertiary,
+                        fontFamily: tokens.typography.sans,
+                      },
+                    ]}
+                  >
+                    {formatEventTime(detail.event.startTime)}
+                    {detail.event.location
+                      ? ` · ${detail.event.location}`
+                      : detail.event.format
+                        ? ` · ${detail.event.format}`
+                        : ""}
+                  </Text>
+                </View>
+                <Pressable
+                  accessibilityLabel="Close room"
+                  onPress={onClose}
+                  style={({ pressed }) => [
+                    styles.closeButton,
+                    {
+                      borderColor: tokens.colors.border,
+                      borderRadius: tokens.radius.sm,
+                    },
+                    pressed && styles.pressed,
+                  ]}
+                >
+                  <FontAwesome
+                    name="close"
+                    size={13}
+                    color={tokens.colors.textSecondary}
+                  />
+                </Pressable>
+              </View>
+
+              <View
+                style={[
+                  styles.viewerChip,
+                  {
+                    backgroundColor: tokens.colors.surfaceMuted,
+                    borderRadius: tokens.radius.sm,
+                  },
+                ]}
+              >
+                <View
+                  style={[
+                    styles.statusDot,
+                    {
+                      backgroundColor: detail.viewer.isAttending
+                        ? tokens.colors.accent
+                        : tokens.colors.textTertiary,
+                    },
+                  ]}
+                />
+                <Text
+                  style={[
+                    styles.viewerText,
+                    {
+                      color: tokens.colors.textSecondary,
+                      fontFamily: tokens.typography.sans,
+                    },
+                  ]}
+                >
+                  {getViewerLabel(detail.viewer)}
+                </Text>
+              </View>
+
+              <View style={styles.actionRow}>
+                <ActionButton
+                  active={detail.viewer.isSaved}
+                  label={detail.viewer.isSaved ? "Saved" : "Save"}
+                  loading={pendingAction === "save"}
+                  onPress={handleToggleSave}
+                />
+                <ActionButton
+                  active={detail.viewer.isAttending}
+                  label={detail.viewer.isAttending ? "Going" : "I'm going"}
+                  loading={pendingAction === "going"}
+                  onPress={handleToggleGoing}
+                />
+              </View>
+
+              {detail.viewer.isAttending && !detail.viewer.isVisible ? (
+                <View
+                  style={[
+                    styles.nudge,
+                    {
+                      backgroundColor: tokens.colors.accentSoft,
+                      borderColor: tokens.colors.accentSoft,
+                      borderRadius: tokens.radius.sm,
+                    },
+                  ]}
+                >
+                  <View style={styles.nudgeCopy}>
+                    <Text
+                      style={[
+                        styles.nudgeTitle,
+                        {
+                          color: tokens.colors.textPrimary,
+                          fontFamily: tokens.typography.sans,
+                        },
+                      ]}
+                    >
+                      You're hidden in this room
+                    </Text>
+                    <Text
+                      style={[
+                        styles.nudgeBody,
+                        {
+                          color: tokens.colors.textSecondary,
+                          fontFamily: tokens.typography.sans,
+                        },
+                      ]}
+                    >
+                      Go visible so attendees can see you here.
+                    </Text>
+                  </View>
+                  <Pressable
+                    accessibilityRole="button"
+                    disabled={pendingAction === "visibility"}
+                    onPress={handleGoVisible}
+                    style={({ pressed }) => [
+                      styles.nudgeAction,
+                      {
+                        backgroundColor: tokens.colors.accent,
+                        borderRadius: tokens.radius.sm,
+                      },
+                      pressed && styles.pressed,
+                    ]}
+                  >
+                    <Text
+                      style={{
+                        color: tokens.colors.textInverse,
+                        fontFamily: tokens.typography.sans,
+                        fontSize: 12,
+                        fontWeight: "700",
+                      }}
+                    >
+                      {pendingAction === "visibility"
+                        ? "Updating..."
+                        : "Go visible"}
+                    </Text>
+                  </Pressable>
+                </View>
+              ) : null}
+
+              <View style={styles.statsRow}>
+                <StatTile
+                  label="Here"
+                  value={detail.stats.visibleAttendeeCount}
+                />
+                <StatTile
+                  label="Network"
+                  value={detail.stats.networkAttendingCount}
+                  emphasis
+                />
+                <StatTile
+                  label="Active 24h"
+                  value={detail.stats.activeNowCount}
+                />
+                <StatTile
+                  label="Total"
+                  value={detail.stats.totalAttendeeCount}
+                  muted
+                />
+              </View>
+
+              {detail.attendees.length > 0 ? (
+                <>
+                  <SectionLabel title="Who's here" />
+                  <View
+                    style={[
+                      styles.attendeeList,
+                      {
+                        backgroundColor: tokens.colors.surface,
+                        borderColor: tokens.colors.border,
+                        borderRadius: tokens.radius.sm,
+                      },
+                    ]}
+                  >
+                    {detail.attendees.map((attendee, index) => (
+                      <AttendeeRow
+                        key={attendee.id}
+                        attendee={attendee}
+                        isLast={index === detail.attendees.length - 1}
+                        onPress={() => openProfile(attendee.username)}
+                      />
+                    ))}
+                  </View>
+                </>
+              ) : null}
+
+              <Pressable
+                accessibilityRole="button"
+                onPress={() =>
+                  navigateToThreads(
+                    detail.stats.threadCount === 0 ? "new" : "list",
+                  )
+                }
+                style={({ pressed }) => [
+                  styles.threadsTile,
+                  {
+                    backgroundColor: tokens.colors.surface,
+                    borderColor: tokens.colors.border,
+                    borderRadius: tokens.radius.sm,
+                  },
+                  pressed && { backgroundColor: tokens.colors.surfaceMuted },
+                ]}
+              >
+                <View style={styles.threadsTileCopy}>
+                  <Text
+                    style={[
+                      styles.threadsTileLabel,
+                      {
+                        color: tokens.colors.textPrimary,
+                        fontFamily: tokens.typography.sans,
+                      },
+                    ]}
+                  >
+                    {detail.stats.threadCount === 0
+                      ? "No threads yet"
+                      : `Threads · ${detail.stats.threadCount}`}
+                  </Text>
+                </View>
+                <Text
+                  style={[
+                    styles.threadsTileAction,
+                    {
+                      color: tokens.colors.accent,
+                      fontFamily: tokens.typography.sans,
+                    },
+                  ]}
+                >
+                  {detail.stats.threadCount === 0
+                    ? "Start one →"
+                    : "View threads →"}
+                </Text>
+              </Pressable>
+
+              {detail.signals.length > 0 ? (
+                <>
+                  <SectionLabel title="Recent activity" />
+                  <View
+                    style={[
+                      styles.signalList,
+                      {
+                        backgroundColor: tokens.colors.surface,
+                        borderColor: tokens.colors.border,
+                        borderRadius: tokens.radius.sm,
+                      },
+                    ]}
+                  >
+                    {detail.signals.map((signal, index) => (
+                      <SignalRow
+                        key={signal.id}
+                        signal={signal}
+                        isLast={index === detail.signals.length - 1}
+                        onPress={() => openProfile(signal.actor.username)}
+                      />
+                    ))}
+                  </View>
+                </>
+              ) : null}
+
+              <Pressable
+                accessibilityRole="button"
+                onPress={openFullEvent}
+                style={({ pressed }) => [
+                  styles.footerLink,
+                  {
+                    borderColor: tokens.colors.border,
+                    borderRadius: tokens.radius.sm,
+                  },
+                  pressed && styles.pressed,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.footerLinkText,
+                    {
+                      color: tokens.colors.textPrimary,
+                      fontFamily: tokens.typography.sans,
+                    },
+                  ]}
+                >
+                  Open full event
+                </Text>
+                <FontAwesome
+                  name="long-arrow-right"
+                  size={12}
+                  color={tokens.colors.textSecondary}
+                />
+              </Pressable>
+            </ScrollView>
+          ) : null}
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+function ActionButton({
+  active,
+  label,
+  loading,
+  onPress,
+}: {
+  active: boolean;
+  label: string;
+  loading: boolean;
+  onPress: () => void;
+}) {
+  const { tokens } = useAppTheme();
+  const background = active ? tokens.colors.accent : tokens.colors.surface;
+  const borderColor = active ? tokens.colors.accent : tokens.colors.border;
+  const textColor = active
+    ? tokens.colors.textInverse
+    : tokens.colors.textPrimary;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      disabled={loading}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.actionButton,
+        {
+          backgroundColor: background,
+          borderColor,
+          borderRadius: tokens.radius.sm,
+        },
+        pressed && styles.pressed,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator
+          color={active ? tokens.colors.textInverse : tokens.colors.textPrimary}
+          size="small"
+        />
+      ) : (
+        <Text
+          style={{
+            color: textColor,
+            fontFamily: tokens.typography.sans,
+            fontSize: 13,
+            fontWeight: "700",
+          }}
+        >
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
+function StatTile({
+  emphasis,
+  label,
+  muted,
+  value,
+}: {
+  emphasis?: boolean;
+  label: string;
+  muted?: boolean;
+  value: number;
+}) {
+  const { tokens } = useAppTheme();
+  const valueColor = emphasis
+    ? tokens.colors.accent
+    : muted
+      ? tokens.colors.textTertiary
+      : tokens.colors.textPrimary;
+
+  return (
+    <View
+      style={[
+        styles.statTile,
+        {
+          backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
+          borderRadius: tokens.radius.sm,
+        },
+      ]}
+    >
+      <Text
+        style={{
+          color: valueColor,
+          fontFamily: tokens.typography.sans,
+          fontSize: 18,
+          fontWeight: "700",
+          letterSpacing: -0.3,
+          lineHeight: 22,
+        }}
+      >
+        {value}
+      </Text>
+      <Text
+        style={{
+          color: tokens.colors.textTertiary,
+          fontFamily: tokens.typography.sans,
+          fontSize: 11,
+          fontWeight: "600",
+          letterSpacing: 0.2,
+          lineHeight: 14,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function AttendeeRow({
+  attendee,
+  isLast,
+  onPress,
+}: {
+  attendee: MobileCommunityRoomAttendee;
+  isLast: boolean;
+  onPress: () => void;
+}) {
+  const { tokens } = useAppTheme();
+  const displayName = attendee.fullName || `@${attendee.username}`;
+  const subline = attendee.matchReason ?? attendee.headline ?? attendee.location;
+  const relationshipLabel = RELATIONSHIP_LABEL[attendee.relationship];
+  const isMutual = attendee.relationship === "mutual";
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.attendeeRow,
+        !isLast && {
+          borderBottomColor: tokens.colors.divider,
+          borderBottomWidth: 1,
+        },
+        pressed && { backgroundColor: tokens.colors.surfaceMuted },
+      ]}
+    >
+      <Avatar
+        avatarUrl={attendee.avatarUrl}
+        name={displayName}
+        size={36}
+      />
+      <View style={styles.attendeeCopy}>
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.attendeeName,
+            {
+              color: tokens.colors.textPrimary,
+              fontFamily: tokens.typography.sans,
+            },
+          ]}
+        >
+          {displayName}
+        </Text>
+        {subline ? (
+          <Text
+            numberOfLines={1}
+            style={[
+              styles.attendeeSubline,
+              {
+                color: tokens.colors.textTertiary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+          >
+            {subline}
+          </Text>
+        ) : null}
+      </View>
+      {relationshipLabel ? (
+        <Text
+          style={{
+            color: isMutual ? tokens.colors.accent : tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+            fontSize: 11,
+            fontWeight: "700",
+            letterSpacing: 0.2,
+          }}
+        >
+          {relationshipLabel}
+        </Text>
+      ) : null}
+    </Pressable>
+  );
+}
+
+function SignalRow({
+  isLast,
+  onPress,
+  signal,
+}: {
+  isLast: boolean;
+  onPress: () => void;
+  signal: MobileCommunityRoomSignal;
+}) {
+  const { tokens } = useAppTheme();
+  const copy = getSignalCopy(signal);
+  const time = formatRelative(signal.occurredAt);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.signalRow,
+        !isLast && {
+          borderBottomColor: tokens.colors.divider,
+          borderBottomWidth: 1,
+        },
+        pressed && { backgroundColor: tokens.colors.surfaceMuted },
+      ]}
+    >
+      <Avatar
+        avatarUrl={signal.actor.avatarUrl}
+        name={signal.actor.fullName || signal.actor.username}
+        size={24}
+      />
+      <Text
+        numberOfLines={1}
+        style={[
+          styles.signalCopy,
+          {
+            color: tokens.colors.textSecondary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {copy}
+      </Text>
+      <Text
+        style={{
+          color: tokens.colors.textTertiary,
+          fontFamily: tokens.typography.sans,
+          fontSize: 11,
+          fontWeight: "500",
+        }}
+      >
+        {time}
+      </Text>
+    </Pressable>
+  );
+}
+
+function SectionLabel({ title }: { title: string }) {
+  const { tokens } = useAppTheme();
+  return (
+    <Text
+      style={[
+        styles.sectionLabel,
+        {
+          color: tokens.colors.textTertiary,
+          fontFamily: tokens.typography.sans,
+        },
+      ]}
+    >
+      {title}
+    </Text>
+  );
+}
+
+function EmptyNote({ text }: { text: string }) {
+  const { tokens } = useAppTheme();
+  return (
+    <View
+      style={[
+        styles.emptyNote,
+        {
+          backgroundColor: tokens.colors.surface,
+          borderColor: tokens.colors.border,
+          borderRadius: tokens.radius.sm,
+        },
+      ]}
+    >
+      <Text
+        style={[
+          styles.emptyText,
+          {
+            color: tokens.colors.textTertiary,
+            fontFamily: tokens.typography.sans,
+          },
+        ]}
+      >
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+function isSafeAvatarUrl(url: string | null | undefined): url is string {
+  if (!url) return false;
+  return /^https?:\/\//i.test(url);
+}
+
+function Avatar({
+  avatarUrl,
+  name,
+  size,
+}: {
+  avatarUrl: string | null;
+  name: string;
+  size: number;
+}) {
+  const { tokens } = useAppTheme();
+
+  if (isSafeAvatarUrl(avatarUrl)) {
+    return (
+      <Image
+        source={{ uri: avatarUrl }}
+        style={{ width: size, height: size, borderRadius: size / 2 }}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={{
+        alignItems: "center",
+        backgroundColor: tokens.colors.surfaceMuted,
+        borderRadius: size / 2,
+        height: size,
+        justifyContent: "center",
+        width: size,
+      }}
+    >
+      <Text
+        style={{
+          color: tokens.colors.textPrimary,
+          fontFamily: tokens.typography.sans,
+          fontSize: size < 30 ? 10 : 12,
+          fontWeight: "700",
+        }}
+      >
+        {getInitials(name)}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  actionButton: {
+    alignItems: "center",
+    borderWidth: 1,
+    flex: 1,
+    justifyContent: "center",
+    minHeight: 34,
+    paddingHorizontal: 12,
+  },
+  actionRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  attendeeCopy: {
+    flex: 1,
+    gap: 2,
+  },
+  attendeeList: {
+    borderWidth: 1,
+    overflow: "hidden",
+  },
+  attendeeName: {
+    fontSize: 14,
+    fontWeight: "600",
+    letterSpacing: -0.1,
+    lineHeight: 18,
+  },
+  attendeeRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 10,
+    minHeight: 52,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  attendeeSubline: {
+    fontSize: 12,
+    fontWeight: "500",
+    lineHeight: 16,
+  },
+  centered: {
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 32,
+  },
+  closeButton: {
+    alignItems: "center",
+    borderWidth: 1,
+    height: 28,
+    justifyContent: "center",
+    width: 28,
+  },
+  content: {
+    gap: 14,
+    paddingBottom: 16,
+  },
+  dragHandle: {
+    alignSelf: "center",
+    borderRadius: 999,
+    height: 4,
+    marginBottom: 12,
+    width: 36,
+  },
+  emptyNote: {
+    borderWidth: 1,
+    padding: 12,
+  },
+  emptyText: {
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+  },
+  errorText: {
+    fontSize: 13,
+    fontWeight: "500",
+    textAlign: "center",
+  },
+  footerLink: {
+    alignItems: "center",
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 8,
+    justifyContent: "center",
+    minHeight: 36,
+    paddingHorizontal: 12,
+  },
+  footerLinkText: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  headerCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  headerRow: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    gap: 12,
+  },
+  nudge: {
+    alignItems: "center",
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 10,
+    padding: 10,
+  },
+  nudgeAction: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 28,
+    paddingHorizontal: 12,
+  },
+  nudgeBody: {
+    fontSize: 12,
+    fontWeight: "500",
+    lineHeight: 16,
+  },
+  nudgeCopy: {
+    flex: 1,
+    gap: 2,
+  },
+  nudgeTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: -0.1,
+    lineHeight: 17,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  pressed: {
+    opacity: 0.82,
+  },
+  retryButton: {
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  safeArea: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.9,
+    lineHeight: 16,
+    paddingTop: 4,
+  },
+  sheet: {
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    borderTopWidth: 1,
+    maxHeight: "82%",
+    paddingHorizontal: 16,
+    paddingTop: 10,
+  },
+  signalCopy: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+  },
+  signalList: {
+    borderWidth: 1,
+    overflow: "hidden",
+  },
+  threadsTile: {
+    alignItems: "center",
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 10,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  threadsTileAction: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  threadsTileCopy: {
+    flex: 1,
+  },
+  threadsTileLabel: {
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: -0.1,
+  },
+  signalRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 10,
+    minHeight: 40,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  statTile: {
+    alignItems: "flex-start",
+    borderWidth: 1,
+    flex: 1,
+    gap: 2,
+    minHeight: 56,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  statsRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  statusDot: {
+    borderRadius: 2,
+    height: 5,
+    width: 5,
+  },
+  subMeta: {
+    fontSize: 12,
+    fontWeight: "500",
+    lineHeight: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    letterSpacing: -0.3,
+    lineHeight: 22,
+  },
+  viewerChip: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
+  viewerText: {
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: -0.05,
+  },
+});

--- a/apps/mobile/src/components/community/CommunityThreadActionMenu.tsx
+++ b/apps/mobile/src/components/community/CommunityThreadActionMenu.tsx
@@ -1,0 +1,146 @@
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useAppTheme } from "../../providers/ThemeProvider";
+
+export type ThreadActionKey =
+  | "edit"
+  | "delete"
+  | "report"
+  | "copyLink"
+  | "cancel";
+
+export interface ThreadActionOption {
+  key: ThreadActionKey;
+  label: string;
+  destructive?: boolean;
+}
+
+interface CommunityThreadActionMenuProps {
+  visible: boolean;
+  title?: string;
+  options: ThreadActionOption[];
+  onSelect: (key: ThreadActionKey) => void;
+  onDismiss: () => void;
+}
+
+export function CommunityThreadActionMenu({
+  onDismiss,
+  onSelect,
+  options,
+  title,
+  visible,
+}: CommunityThreadActionMenuProps) {
+  const { tokens } = useAppTheme();
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onDismiss}
+      transparent
+      visible={visible}
+    >
+      <Pressable
+        accessibilityLabel="Close menu"
+        style={[styles.overlay, { backgroundColor: tokens.colors.overlay }]}
+        onPress={onDismiss}
+      />
+      <SafeAreaView edges={["bottom"]} style={styles.safeArea}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: tokens.colors.shellElevated,
+              borderTopColor: tokens.colors.borderStrong,
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.dragHandle,
+              { backgroundColor: tokens.colors.borderStrong },
+            ]}
+          />
+          {title ? (
+            <Text
+              style={[
+                styles.title,
+                {
+                  color: tokens.colors.textTertiary,
+                  fontFamily: tokens.typography.sans,
+                },
+              ]}
+            >
+              {title}
+            </Text>
+          ) : null}
+          {options.map((option, index) => (
+            <Pressable
+              key={option.key}
+              accessibilityRole="button"
+              onPress={() => onSelect(option.key)}
+              style={({ pressed }) => [
+                styles.option,
+                index < options.length - 1 && {
+                  borderBottomColor: tokens.colors.divider,
+                  borderBottomWidth: 1,
+                },
+                pressed && { backgroundColor: tokens.colors.surfaceMuted },
+              ]}
+            >
+              <Text
+                style={{
+                  color: option.destructive
+                    ? tokens.colors.danger
+                    : tokens.colors.textPrimary,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 15,
+                  fontWeight: option.destructive ? "700" : "600",
+                }}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  dragHandle: {
+    alignSelf: "center",
+    borderRadius: 999,
+    height: 4,
+    marginBottom: 12,
+    width: 36,
+  },
+  option: {
+    alignItems: "flex-start",
+    justifyContent: "center",
+    minHeight: 48,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  safeArea: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    borderTopWidth: 1,
+    paddingTop: 10,
+  },
+  title: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+  },
+});

--- a/apps/mobile/src/components/community/CommunityThreadReportSheet.tsx
+++ b/apps/mobile/src/components/community/CommunityThreadReportSheet.tsx
@@ -1,0 +1,427 @@
+import type {
+  CommunityReportInput,
+  CommunityReportSubjectType,
+} from "@kurecal/domain";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { submitMobileCommunityReport } from "../../lib/mobileApi";
+import { useAppTheme } from "../../providers/ThemeProvider";
+
+type Reason = CommunityReportInput["reason"];
+
+const REASONS: Array<{ key: Reason; label: string; description: string }> = [
+  { key: "spam", label: "Spam", description: "Repetitive or off-topic" },
+  {
+    key: "harassment",
+    label: "Harassment",
+    description: "Targeted, personal attacks",
+  },
+  { key: "hate", label: "Hate speech", description: "Slurs, threats, bigotry" },
+  {
+    key: "sexual-content",
+    label: "Sexual content",
+    description: "Explicit or inappropriate",
+  },
+  {
+    key: "misinformation",
+    label: "Misinformation",
+    description: "False or misleading claims",
+  },
+  { key: "other", label: "Other", description: "Tell us in the notes" },
+];
+
+interface CommunityThreadReportSheetProps {
+  visible: boolean;
+  subjectType: CommunityReportSubjectType;
+  subjectId: string | null;
+  onDismiss: () => void;
+  onSubmitted?: () => void;
+}
+
+export function CommunityThreadReportSheet({
+  onDismiss,
+  onSubmitted,
+  subjectId,
+  subjectType,
+  visible,
+}: CommunityThreadReportSheetProps) {
+  const { tokens } = useAppTheme();
+  const [reason, setReason] = useState<Reason | null>(null);
+  const [details, setDetails] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setReason(null);
+      setDetails("");
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [visible]);
+
+  const canSubmit = Boolean(reason) && !submitting && Boolean(subjectId);
+
+  const handleSubmit = async () => {
+    if (!reason || !subjectId) {
+      setError("Pick a reason first.");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await submitMobileCommunityReport({
+        subjectType,
+        subjectId,
+        reason,
+        details: details.trim() || undefined,
+      });
+      onSubmitted?.();
+      onDismiss();
+    } catch (nextError) {
+      // Always show a generic message in the UI; log the raw error for devs.
+      console.warn("submitMobileCommunityReport failed", nextError);
+      setError("Couldn't submit the report. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onDismiss}
+      transparent
+      visible={visible}
+    >
+      <Pressable
+        accessibilityLabel="Close report sheet"
+        style={[styles.overlay, { backgroundColor: tokens.colors.overlay }]}
+        onPress={onDismiss}
+      />
+      <SafeAreaView edges={["bottom"]} style={styles.safeArea}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: tokens.colors.shellElevated,
+              borderTopColor: tokens.colors.borderStrong,
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.dragHandle,
+              { backgroundColor: tokens.colors.borderStrong },
+            ]}
+          />
+          <Text
+            style={[
+              styles.title,
+              {
+                color: tokens.colors.textPrimary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+          >
+            Report content
+          </Text>
+          <Text
+            style={[
+              styles.subtitle,
+              {
+                color: tokens.colors.textTertiary,
+                fontFamily: tokens.typography.sans,
+              },
+            ]}
+          >
+            Help us understand what's wrong. Our team reviews every report.
+          </Text>
+
+          {REASONS.map((entry, index) => {
+            const selected = reason === entry.key;
+            return (
+              <Pressable
+                key={entry.key}
+                accessibilityRole="button"
+                onPress={() => setReason(entry.key)}
+                style={({ pressed }) => [
+                  styles.reasonRow,
+                  index < REASONS.length - 1 && {
+                    borderBottomColor: tokens.colors.divider,
+                    borderBottomWidth: 1,
+                  },
+                  pressed && {
+                    backgroundColor: tokens.colors.surfaceMuted,
+                  },
+                ]}
+              >
+                <View style={styles.reasonCopy}>
+                  <Text
+                    style={{
+                      color: tokens.colors.textPrimary,
+                      fontFamily: tokens.typography.sans,
+                      fontSize: 14,
+                      fontWeight: "700",
+                    }}
+                  >
+                    {entry.label}
+                  </Text>
+                  <Text
+                    style={{
+                      color: tokens.colors.textTertiary,
+                      fontFamily: tokens.typography.sans,
+                      fontSize: 12,
+                      fontWeight: "500",
+                    }}
+                  >
+                    {entry.description}
+                  </Text>
+                </View>
+                <View
+                  style={[
+                    styles.radio,
+                    {
+                      borderColor: selected
+                        ? tokens.colors.accent
+                        : tokens.colors.border,
+                    },
+                  ]}
+                >
+                  {selected ? (
+                    <View
+                      style={[
+                        styles.radioDot,
+                        { backgroundColor: tokens.colors.accent },
+                      ]}
+                    />
+                  ) : null}
+                </View>
+              </Pressable>
+            );
+          })}
+
+          <View style={styles.detailsField}>
+            <Text
+              style={[
+                styles.fieldLabel,
+                {
+                  color: tokens.colors.textTertiary,
+                  fontFamily: tokens.typography.sans,
+                },
+              ]}
+            >
+              Add details (optional)
+            </Text>
+            <TextInput
+              accessibilityLabel="Report details"
+              editable={!submitting}
+              maxLength={1500}
+              multiline
+              onChangeText={setDetails}
+              placeholder="Anything else our team should know?"
+              placeholderTextColor={tokens.colors.textTertiary}
+              style={[
+                styles.detailsInput,
+                {
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                  color: tokens.colors.textPrimary,
+                  fontFamily: tokens.typography.sans,
+                },
+              ]}
+              value={details}
+            />
+          </View>
+
+          {error ? (
+            <Text
+              style={{
+                color: tokens.colors.danger,
+                fontFamily: tokens.typography.sans,
+                fontSize: 12,
+                fontWeight: "500",
+                paddingHorizontal: 16,
+              }}
+            >
+              {error}
+            </Text>
+          ) : null}
+
+          <View style={styles.footer}>
+            <Pressable
+              accessibilityRole="button"
+              disabled={submitting}
+              onPress={onDismiss}
+              style={({ pressed }) => [
+                styles.cancelButton,
+                {
+                  borderColor: tokens.colors.border,
+                  borderRadius: tokens.radius.sm,
+                },
+                pressed && styles.pressed,
+              ]}
+            >
+              <Text
+                style={{
+                  color: tokens.colors.textSecondary,
+                  fontFamily: tokens.typography.sans,
+                  fontSize: 13,
+                  fontWeight: "700",
+                }}
+              >
+                Cancel
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              disabled={!canSubmit}
+              onPress={handleSubmit}
+              style={({ pressed }) => [
+                styles.submitButton,
+                {
+                  backgroundColor: canSubmit
+                    ? tokens.colors.accent
+                    : tokens.colors.accentSoft,
+                  borderRadius: tokens.radius.sm,
+                },
+                pressed && canSubmit && styles.pressed,
+              ]}
+            >
+              {submitting ? (
+                <ActivityIndicator color={tokens.colors.textInverse} />
+              ) : (
+                <Text
+                  style={{
+                    color: canSubmit
+                      ? tokens.colors.textInverse
+                      : tokens.colors.textTertiary,
+                    fontFamily: tokens.typography.sans,
+                    fontSize: 13,
+                    fontWeight: "700",
+                  }}
+                >
+                  Submit report
+                </Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  cancelButton: {
+    alignItems: "center",
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 36,
+    paddingHorizontal: 14,
+  },
+  detailsField: {
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  detailsInput: {
+    borderWidth: 1,
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+    minHeight: 72,
+    padding: 10,
+    textAlignVertical: "top",
+  },
+  dragHandle: {
+    alignSelf: "center",
+    borderRadius: 999,
+    height: 4,
+    marginBottom: 12,
+    width: 36,
+  },
+  fieldLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+  },
+  footer: {
+    flexDirection: "row",
+    gap: 8,
+    justifyContent: "flex-end",
+    padding: 16,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  pressed: {
+    opacity: 0.82,
+  },
+  radio: {
+    alignItems: "center",
+    borderRadius: 999,
+    borderWidth: 1,
+    height: 18,
+    justifyContent: "center",
+    width: 18,
+  },
+  radioDot: {
+    borderRadius: 999,
+    height: 8,
+    width: 8,
+  },
+  reasonCopy: {
+    flex: 1,
+    gap: 2,
+  },
+  reasonRow: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 10,
+    minHeight: 56,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  safeArea: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    borderTopWidth: 1,
+    maxHeight: "90%",
+    paddingTop: 10,
+  },
+  submitButton: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 36,
+    paddingHorizontal: 18,
+  },
+  subtitle: {
+    fontSize: 12,
+    fontWeight: "500",
+    paddingBottom: 14,
+    paddingHorizontal: 16,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: "700",
+    letterSpacing: -0.2,
+    paddingHorizontal: 16,
+    paddingTop: 2,
+  },
+});

--- a/apps/mobile/src/lib/mobileApi.test.ts
+++ b/apps/mobile/src/lib/mobileApi.test.ts
@@ -26,6 +26,7 @@ import {
   loadMobileCommunityCircle,
   loadMobileCommunityHome,
   loadMobileCommunityPost,
+  loadMobileEventThreadComments,
   loadMobileDiscoverFeed,
   loadMobileEventDetail,
   loadMobileFollowStatus,
@@ -202,6 +203,43 @@ describe('mobile api helpers', () => {
 
     await expect(loadMobileEventDetail('missing-event')).rejects.toThrow(
       'Event not found'
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it('loads paged event thread comments with cursor query params', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            comments: [],
+            nextCursor: 'next-page',
+            hasMore: true,
+            loadedCount: 0,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const page = await loadMobileEventThreadComments(
+      '11111111-1111-4111-8111-111111111111',
+      '22222222-2222-4222-8222-222222222222',
+      {
+        cursor: 'cursor-one',
+        limit: 25,
+        sort: 'newest',
+      }
+    );
+
+    expect(page.hasMore).toBe(true);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      'https://mobile.kurecal.test/api/mobile/community/rooms/11111111-1111-4111-8111-111111111111/threads/22222222-2222-4222-8222-222222222222/comments?sort=newest&cursor=cursor-one&limit=25'
     );
 
     fetchSpy.mockRestore();

--- a/apps/mobile/src/lib/mobileApi.ts
+++ b/apps/mobile/src/lib/mobileApi.ts
@@ -12,6 +12,15 @@ import {
   mobileCommunityCirclePageSchema,
   mobileCommunityHomeSchema,
   mobileCommunityPostPageSchema,
+  mobileCommunityRoomDetailSchema,
+  mobileCommunityRoomThreadCommentDraftSchema,
+  mobileCommunityRoomThreadCommentEditDraftSchema,
+  mobileCommunityRoomThreadCommentSchema,
+  mobileCommunityRoomThreadDetailSchema,
+  mobileCommunityRoomThreadDraftSchema,
+  mobileCommunityRoomThreadEditDraftSchema,
+  mobileCommunityRoomThreadListSchema,
+  mobileCommunityRoomThreadSchema,
   mobileDashboardSummarySchema,
   mobileDiscoverFeedRequestSchema,
   mobileDiscoverFeedSchema,
@@ -44,6 +53,16 @@ import {
   type MobileCommunityCirclePage,
   type MobileCommunityHome,
   type MobileCommunityPostPage,
+  type MobileCommunityRoomCommentSort,
+  type MobileCommunityRoomDetail,
+  type MobileCommunityRoomThread,
+  type MobileCommunityRoomThreadComment,
+  type MobileCommunityRoomThreadCommentDraft,
+  type MobileCommunityRoomThreadCommentEditDraft,
+  type MobileCommunityRoomThreadDetail,
+  type MobileCommunityRoomThreadDraft,
+  type MobileCommunityRoomThreadEditDraft,
+  type MobileCommunityRoomThreadList,
   type MobileDashboardSummary,
   type MobileDiscoverFeed,
   type MobileDiscoverFeedRequest,
@@ -249,6 +268,177 @@ export async function loadMobileCalendarFeed(
 
 export async function loadMobileCommunityHome(): Promise<MobileCommunityHome> {
   return fetchMobileContract('/api/mobile/community', mobileCommunityHomeSchema);
+}
+
+export async function loadMobileCommunityRoom(
+  eventId: string
+): Promise<MobileCommunityRoomDetail> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}`,
+    mobileCommunityRoomDetailSchema
+  );
+}
+
+export async function createMobileCommunityRoomThread(
+  eventId: string,
+  draft: MobileCommunityRoomThreadDraft
+): Promise<MobileCommunityRoomThread> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  const payload = mobileCommunityRoomThreadDraftSchema.parse(draft);
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads`,
+    mobileCommunityRoomThreadSchema,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }
+  );
+}
+
+export async function loadMobileEventThreads(
+  eventId: string,
+  cursor?: string | null
+): Promise<MobileCommunityRoomThreadList> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  const params = new URLSearchParams();
+  if (cursor) {
+    params.set('cursor', cursor);
+  }
+  const query = params.toString();
+  const path = `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads${query ? `?${query}` : ''}`;
+  return fetchMobileContract(path, mobileCommunityRoomThreadListSchema);
+}
+
+export async function loadMobileEventThread(
+  eventId: string,
+  threadId: string,
+  sort?: MobileCommunityRoomCommentSort
+): Promise<MobileCommunityRoomThreadDetail> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  const query = sort ? `?sort=${encodeURIComponent(sort)}` : '';
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}${query}`,
+    mobileCommunityRoomThreadDetailSchema
+  );
+}
+
+export async function updateMobileEventThread(
+  eventId: string,
+  threadId: string,
+  draft: MobileCommunityRoomThreadEditDraft
+): Promise<MobileCommunityRoomThread> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  const payload = mobileCommunityRoomThreadEditDraftSchema.parse(draft);
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}`,
+    mobileCommunityRoomThreadSchema,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    }
+  );
+}
+
+export async function deleteMobileEventThread(
+  eventId: string,
+  threadId: string
+): Promise<void> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  await fetchMobileEnvelope(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}`,
+    { method: 'DELETE' }
+  );
+}
+
+export async function updateMobileEventThreadComment(
+  eventId: string,
+  threadId: string,
+  commentId: string,
+  draft: MobileCommunityRoomThreadCommentEditDraft
+): Promise<MobileCommunityRoomThreadComment> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  if (!commentId.trim()) {
+    throw new Error('Comment id is required');
+  }
+  const payload =
+    mobileCommunityRoomThreadCommentEditDraftSchema.parse(draft);
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}`,
+    mobileCommunityRoomThreadCommentSchema,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    }
+  );
+}
+
+export async function deleteMobileEventThreadComment(
+  eventId: string,
+  threadId: string,
+  commentId: string
+): Promise<void> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  if (!commentId.trim()) {
+    throw new Error('Comment id is required');
+  }
+  await fetchMobileEnvelope(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}`,
+    { method: 'DELETE' }
+  );
+}
+
+export async function createMobileEventThreadComment(
+  eventId: string,
+  threadId: string,
+  draft: MobileCommunityRoomThreadCommentDraft
+): Promise<MobileCommunityRoomThreadComment> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  const payload = mobileCommunityRoomThreadCommentDraftSchema.parse(draft);
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}/comments`,
+    mobileCommunityRoomThreadCommentSchema,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }
+  );
 }
 
 export async function loadMobileCommunityCircle(

--- a/apps/mobile/src/lib/mobileApi.ts
+++ b/apps/mobile/src/lib/mobileApi.ts
@@ -15,6 +15,7 @@ import {
   mobileCommunityRoomDetailSchema,
   mobileCommunityRoomThreadCommentDraftSchema,
   mobileCommunityRoomThreadCommentEditDraftSchema,
+  mobileCommunityRoomThreadCommentPageSchema,
   mobileCommunityRoomThreadCommentSchema,
   mobileCommunityRoomThreadDetailSchema,
   mobileCommunityRoomThreadDraftSchema,
@@ -59,6 +60,7 @@ import {
   type MobileCommunityRoomThreadComment,
   type MobileCommunityRoomThreadCommentDraft,
   type MobileCommunityRoomThreadCommentEditDraft,
+  type MobileCommunityRoomThreadCommentPage,
   type MobileCommunityRoomThreadDetail,
   type MobileCommunityRoomThreadDraft,
   type MobileCommunityRoomThreadEditDraft,
@@ -331,6 +333,56 @@ export async function loadMobileEventThread(
   return fetchMobileContract(
     `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}${query}`,
     mobileCommunityRoomThreadDetailSchema
+  );
+}
+
+export async function loadMobileEventThreadComments(
+  eventId: string,
+  threadId: string,
+  {
+    cursor,
+    limit,
+    sort,
+  }: {
+    cursor?: string | null;
+    limit?: number;
+    sort?: MobileCommunityRoomCommentSort;
+  } = {}
+): Promise<MobileCommunityRoomThreadCommentPage> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  const params = new URLSearchParams();
+  if (sort) params.set('sort', sort);
+  if (cursor) params.set('cursor', cursor);
+  if (limit != null) params.set('limit', String(limit));
+  const query = params.toString();
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}/comments${query ? `?${query}` : ''}`,
+    mobileCommunityRoomThreadCommentPageSchema
+  );
+}
+
+export async function loadMobileEventThreadComment(
+  eventId: string,
+  threadId: string,
+  commentId: string
+): Promise<MobileCommunityRoomThreadComment> {
+  if (!eventId.trim()) {
+    throw new Error('Event id is required');
+  }
+  if (!threadId.trim()) {
+    throw new Error('Thread id is required');
+  }
+  if (!commentId.trim()) {
+    throw new Error('Comment id is required');
+  }
+  return fetchMobileContract(
+    `/api/mobile/community/rooms/${encodeURIComponent(eventId)}/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(commentId)}`,
+    mobileCommunityRoomThreadCommentSchema
   );
 }
 

--- a/packages/domain/src/community.test.ts
+++ b/packages/domain/src/community.test.ts
@@ -8,6 +8,7 @@ import {
   mobileCommunityHomeSchema,
   mobileCommunityNetworkingHomeSchema,
   mobileCommunityPostPageSchema,
+  mobileCommunityRoomThreadDetailSchema,
   mobilePublicProfileSchema,
   mobileSpeakerDetailSchema,
 } from "./community";
@@ -405,5 +406,36 @@ describe("community domain contracts", () => {
     });
 
     expect(blocked.username).toBe("blocked-member");
+  });
+
+  it("parses paged mobile room thread comments", () => {
+    const parsed = mobileCommunityRoomThreadDetailSchema.parse({
+      thread: {
+        id: "11111111-1111-4111-8111-111111111111",
+        title: "Realtime comments",
+        body: "Discuss live updates.",
+        commentCount: 1,
+        createdAt: "2026-05-16T18:00:00.000Z",
+        lastActivityAt: "2026-05-16T18:01:00.000Z",
+        author: {
+          id: "22222222-2222-4222-8222-222222222222",
+          fullName: "Ada Lovelace",
+          username: "ada",
+          avatarUrl: null,
+          headline: null,
+        },
+        isAuthor: false,
+        editedAt: null,
+      },
+      comments: [],
+      commentPage: {
+        comments: [],
+        nextCursor: "cursor",
+        hasMore: true,
+        loadedCount: 0,
+      },
+    });
+
+    expect(parsed.commentPage.hasMore).toBe(true);
   });
 });

--- a/packages/domain/src/community.ts
+++ b/packages/domain/src/community.ts
@@ -543,6 +543,13 @@ export const mobileCommunityRoomThreadCommentSchema = z.object({
   replies: z.array(mobileCommunityRoomThreadChildCommentSchema),
 });
 
+export const mobileCommunityRoomThreadCommentPageSchema = z.object({
+  comments: z.array(mobileCommunityRoomThreadCommentSchema),
+  nextCursor: z.string().nullable(),
+  hasMore: z.boolean(),
+  loadedCount: z.number().int().nonnegative(),
+});
+
 export const mobileCommunityRoomThreadCommentDraftSchema = z.object({
   body: z.string().trim().min(1).max(2000),
   parentCommentId: z.string().uuid().nullable().optional(),
@@ -560,6 +567,7 @@ export const mobileCommunityRoomCommentSortSchema = z.enum([
 export const mobileCommunityRoomThreadDetailSchema = z.object({
   thread: mobileCommunityRoomThreadSchema,
   comments: z.array(mobileCommunityRoomThreadCommentSchema),
+  commentPage: mobileCommunityRoomThreadCommentPageSchema,
 });
 
 export const mobileFollowStatusSchema = z.object({
@@ -838,6 +846,9 @@ export type MobileCommunityRoomThreadChildComment = z.infer<
 >;
 export type MobileCommunityRoomThreadComment = z.infer<
   typeof mobileCommunityRoomThreadCommentSchema
+>;
+export type MobileCommunityRoomThreadCommentPage = z.infer<
+  typeof mobileCommunityRoomThreadCommentPageSchema
 >;
 export type MobileCommunityRoomThreadCommentDraft = z.infer<
   typeof mobileCommunityRoomThreadCommentDraftSchema

--- a/packages/domain/src/community.ts
+++ b/packages/domain/src/community.ts
@@ -40,8 +40,16 @@ export const communityVoteSchema = z.object({
   voteType: voteValueSchema,
 });
 
+export const communityReportSubjectTypeSchema = z.enum([
+  "post",
+  "comment",
+  "profile",
+  "event_thread",
+  "event_thread_comment",
+]);
+
 export const communityReportSchema = z.object({
-  subjectType: z.enum(["post", "comment", "profile"]),
+  subjectType: communityReportSubjectTypeSchema,
   subjectId: z.string().uuid(),
   reason: z.enum([
     "spam",
@@ -71,7 +79,7 @@ export const communityReportResolutionSchema = z.enum([
 export const communityReportRecordSchema = z.object({
   id: z.string().uuid(),
   reporterId: z.string().uuid(),
-  subjectType: z.enum(["post", "comment", "profile"]),
+  subjectType: communityReportSubjectTypeSchema,
   subjectId: z.string().uuid(),
   reason: communityReportSchema.shape.reason,
   details: z.string().nullable(),
@@ -384,6 +392,176 @@ export const mobileCommunityHubHomeSchema =
       .optional(),
   });
 
+export const mobileCommunityRoomEventSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string(),
+  title: z.string(),
+  startTime: z.string(),
+  endTime: z.string().nullable().optional(),
+  location: z.string().nullable(),
+  format: z.string().nullable(),
+  imageUrl: z.string().nullable().optional(),
+  sourceUrl: z.string().nullable().optional(),
+});
+
+export const mobileCommunityRoomViewerStateSchema = z.object({
+  isAttending: z.boolean(),
+  isSaved: z.boolean(),
+  isVisible: z.boolean(),
+});
+
+export const mobileCommunityRoomStatsSchema = z.object({
+  totalAttendeeCount: z.number().int().nonnegative(),
+  visibleAttendeeCount: z.number().int().nonnegative(),
+  networkAttendingCount: z.number().int().nonnegative(),
+  activeNowCount: z.number().int().nonnegative(),
+  threadCount: z.number().int().nonnegative(),
+});
+
+export const mobileCommunityRoomRelationshipSchema = z.enum([
+  "mutual",
+  "follows_you",
+  "in_network",
+  "stranger",
+]);
+
+export const mobileCommunityRoomAttendeeSchema = z.object({
+  id: z.string().uuid(),
+  fullName: z.string().nullable(),
+  username: z.string(),
+  avatarUrl: z.string().nullable(),
+  headline: z.string().nullable(),
+  currentRole: z.string().nullable(),
+  industry: z.string().nullable(),
+  location: z.string().nullable(),
+  isInNetwork: z.boolean(),
+  followsViewer: z.boolean(),
+  isMutualFollow: z.boolean(),
+  mutualConnectionsCount: z.number().int().nonnegative(),
+  relationship: mobileCommunityRoomRelationshipSchema,
+  matchReason: z.string().nullable(),
+});
+
+export const mobileCommunityRoomSignalKindSchema = z.enum([
+  "joined_attending",
+  "saved",
+  "mutual_arrived",
+]);
+
+export const mobileCommunityRoomSignalActorSchema = z.object({
+  id: z.string().uuid(),
+  fullName: z.string().nullable(),
+  username: z.string(),
+  avatarUrl: z.string().nullable(),
+});
+
+export const mobileCommunityRoomSignalSchema = z.object({
+  id: z.string(),
+  kind: mobileCommunityRoomSignalKindSchema,
+  occurredAt: z.string(),
+  actor: mobileCommunityRoomSignalActorSchema,
+});
+
+export const mobileCommunityRoomThreadAuthorSchema = z.object({
+  id: z.string().uuid(),
+  fullName: z.string().nullable(),
+  username: z.string(),
+  avatarUrl: z.string().nullable(),
+  headline: z.string().nullable().optional(),
+});
+
+export const mobileCommunityRoomThreadSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  body: z.string(),
+  commentCount: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  lastActivityAt: z.string(),
+  author: mobileCommunityRoomThreadAuthorSchema,
+  isAuthor: z.boolean(),
+  editedAt: z.string().nullable(),
+});
+
+export const mobileCommunityRoomThreadDraftSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  body: z.string().trim().min(1).max(5000),
+});
+
+export const mobileCommunityRoomThreadEditDraftSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  body: z.string().trim().min(1).max(5000),
+});
+
+export const mobileCommunityRoomDetailSchema = z.object({
+  event: mobileCommunityRoomEventSchema,
+  viewer: mobileCommunityRoomViewerStateSchema,
+  stats: mobileCommunityRoomStatsSchema,
+  attendees: z.array(mobileCommunityRoomAttendeeSchema),
+  signals: z.array(mobileCommunityRoomSignalSchema),
+});
+
+export const mobileCommunityRoomThreadListSchema = z.object({
+  threads: z.array(mobileCommunityRoomThreadSchema),
+  nextCursor: z.string().nullable(),
+});
+
+export const mobileCommunityRoomThreadCommentAuthorSchema = z.object({
+  id: z.string().uuid(),
+  fullName: z.string().nullable(),
+  username: z.string(),
+  avatarUrl: z.string().nullable(),
+});
+
+// Child comments (depth-1) cannot themselves have nested replies — the service
+// layer collapses any "reply-to-a-reply" onto the top-level parent, capping
+// the tree at one level. Declaring this as a separate non-recursive schema
+// keeps the Zod types ergonomic.
+export const mobileCommunityRoomThreadChildCommentSchema = z.object({
+  id: z.string().uuid(),
+  threadId: z.string().uuid(),
+  parentId: z.string().uuid().nullable(),
+  body: z.string(),
+  createdAt: z.string(),
+  author: mobileCommunityRoomThreadCommentAuthorSchema,
+  isAuthor: z.boolean(),
+  isOp: z.boolean(),
+  isDeleted: z.boolean(),
+  editedAt: z.string().nullable(),
+});
+
+export const mobileCommunityRoomThreadCommentSchema = z.object({
+  id: z.string().uuid(),
+  threadId: z.string().uuid(),
+  parentId: z.string().uuid().nullable(),
+  body: z.string(),
+  createdAt: z.string(),
+  author: mobileCommunityRoomThreadCommentAuthorSchema,
+  isAuthor: z.boolean(),
+  isOp: z.boolean(),
+  isDeleted: z.boolean(),
+  editedAt: z.string().nullable(),
+  replies: z.array(mobileCommunityRoomThreadChildCommentSchema),
+});
+
+export const mobileCommunityRoomThreadCommentDraftSchema = z.object({
+  body: z.string().trim().min(1).max(2000),
+  parentCommentId: z.string().uuid().nullable().optional(),
+});
+
+export const mobileCommunityRoomThreadCommentEditDraftSchema = z.object({
+  body: z.string().trim().min(1).max(2000),
+});
+
+export const mobileCommunityRoomCommentSortSchema = z.enum([
+  "newest",
+  "oldest",
+]);
+
+export const mobileCommunityRoomThreadDetailSchema = z.object({
+  thread: mobileCommunityRoomThreadSchema,
+  comments: z.array(mobileCommunityRoomThreadCommentSchema),
+});
+
 export const mobileFollowStatusSchema = z.object({
   isFollowing: z.boolean(),
   isFollowedBy: z.boolean(),
@@ -615,6 +793,69 @@ export type MobileCommunityNetworkingFollowUpCard = z.infer<
 >;
 export type MobileCommunityNetworkingStarterProfile = z.infer<
   typeof mobileCommunityNetworkingStarterProfileSchema
+>;
+export type MobileCommunityRoomEvent = z.infer<
+  typeof mobileCommunityRoomEventSchema
+>;
+export type MobileCommunityRoomViewerState = z.infer<
+  typeof mobileCommunityRoomViewerStateSchema
+>;
+export type MobileCommunityRoomStats = z.infer<
+  typeof mobileCommunityRoomStatsSchema
+>;
+export type MobileCommunityRoomRelationship = z.infer<
+  typeof mobileCommunityRoomRelationshipSchema
+>;
+export type MobileCommunityRoomAttendee = z.infer<
+  typeof mobileCommunityRoomAttendeeSchema
+>;
+export type MobileCommunityRoomSignalKind = z.infer<
+  typeof mobileCommunityRoomSignalKindSchema
+>;
+export type MobileCommunityRoomSignal = z.infer<
+  typeof mobileCommunityRoomSignalSchema
+>;
+export type MobileCommunityRoomThreadAuthor = z.infer<
+  typeof mobileCommunityRoomThreadAuthorSchema
+>;
+export type MobileCommunityRoomThread = z.infer<
+  typeof mobileCommunityRoomThreadSchema
+>;
+export type MobileCommunityRoomThreadDraft = z.infer<
+  typeof mobileCommunityRoomThreadDraftSchema
+>;
+export type MobileCommunityRoomDetail = z.infer<
+  typeof mobileCommunityRoomDetailSchema
+>;
+export type MobileCommunityRoomThreadList = z.infer<
+  typeof mobileCommunityRoomThreadListSchema
+>;
+export type MobileCommunityRoomThreadCommentAuthor = z.infer<
+  typeof mobileCommunityRoomThreadCommentAuthorSchema
+>;
+export type MobileCommunityRoomThreadChildComment = z.infer<
+  typeof mobileCommunityRoomThreadChildCommentSchema
+>;
+export type MobileCommunityRoomThreadComment = z.infer<
+  typeof mobileCommunityRoomThreadCommentSchema
+>;
+export type MobileCommunityRoomThreadCommentDraft = z.infer<
+  typeof mobileCommunityRoomThreadCommentDraftSchema
+>;
+export type MobileCommunityRoomThreadCommentEditDraft = z.infer<
+  typeof mobileCommunityRoomThreadCommentEditDraftSchema
+>;
+export type MobileCommunityRoomThreadEditDraft = z.infer<
+  typeof mobileCommunityRoomThreadEditDraftSchema
+>;
+export type MobileCommunityRoomCommentSort = z.infer<
+  typeof mobileCommunityRoomCommentSortSchema
+>;
+export type CommunityReportSubjectType = z.infer<
+  typeof communityReportSubjectTypeSchema
+>;
+export type MobileCommunityRoomThreadDetail = z.infer<
+  typeof mobileCommunityRoomThreadDetailSchema
 >;
 export type MobileCommunityPost = z.infer<typeof mobileCommunityPostSchema>;
 export type MobileFollowStatus = z.infer<typeof mobileFollowStatusSchema>;

--- a/src/app/api/community/reports/route.ts
+++ b/src/app/api/community/reports/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { communityReportSchema } from '@/lib/communitySchemas';
+import { gateMutation } from '@/lib/api/mobileMutationRateLimit';
 import { CommunityReportService } from '@/services/communityReportService';
 import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
 
@@ -13,6 +14,12 @@ export async function POST(request: Request) {
       );
     }
 
+    const rateLimitResponse = await gateMutation(
+      'community-report',
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
     const payload = communityReportSchema.parse(await request.json());
     const report = await CommunityReportService.createReport(
       authContext.user.id,
@@ -25,8 +32,9 @@ export async function POST(request: Request) {
       message: 'Thanks. Your report has been submitted for review.',
     });
   } catch (error) {
+    console.error('[community.reports] Failed to submit report', error);
     return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : 'Failed to submit report' },
+      { success: false, error: 'Failed to submit report.' },
       { status: 400 }
     );
   }

--- a/src/app/api/mobile/community/rooms/[eventId]/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  CommunityRoomNotFoundError,
+  CommunityRoomService,
+} from "@/services/communityRoomService";
+import { createServiceClient } from "@/utils/supabase/service";
+import { getAuthenticatedRequestContext } from "@/utils/supabase/requestAuth";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string }> },
+) {
+  try {
+    const { eventId } = await params;
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !serviceRoleKey) {
+      return NextResponse.json(
+        { success: false, error: "Community service is not configured." },
+        { status: 500 },
+      );
+    }
+
+    const readSupabase = createServiceClient(supabaseUrl, serviceRoleKey);
+
+    const data = await CommunityRoomService.getRoomDetail({
+      viewerId: authContext.user.id,
+      eventId,
+      readClient: readSupabase,
+    });
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    if (error instanceof CommunityRoomNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to load community room",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/[commentId]/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/[commentId]/route.ts
@@ -40,6 +40,42 @@ function notFoundResponse(error: CommunityRoomThreadNotFoundError) {
   );
 }
 
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    const { eventId, threadId, commentId } = await params;
+    if (
+      !isValidUuid(eventId) ||
+      !isValidUuid(threadId) ||
+      !isValidUuid(commentId)
+    ) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const readClient = getServiceClient();
+    if (!readClient) return serviceUnavailable();
+
+    const comment = await CommunityRoomThreadService.getThreadComment({
+      eventId,
+      threadId,
+      commentId,
+      viewerId: authContext.user.id,
+      readClient,
+    });
+
+    return NextResponse.json({ success: true, data: comment });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return notFoundResponse(error);
+    }
+    return genericFailure(CONTEXT, "Failed to load comment.", error);
+  }
+}
+
 export async function PATCH(request: Request, { params }: RouteContext) {
   try {
     const { eventId, threadId, commentId } = await params;

--- a/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/[commentId]/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/[commentId]/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { mobileCommunityRoomThreadCommentEditDraftSchema } from "@kurecal/domain";
+
+import { gateMutation } from "@/lib/api/mobileMutationRateLimit";
+import {
+  authRequired,
+  genericFailure,
+  invalidRequest,
+  serviceUnavailable,
+} from "@/lib/api/mobileResponses";
+import { isValidUuid } from "@/lib/uuid";
+import {
+  CommunityRoomThreadNotFoundError,
+  CommunityRoomThreadService,
+} from "@/services/communityRoomThreadService";
+import { createServiceClient } from "@/utils/supabase/service";
+import { getAuthenticatedRequestContext } from "@/utils/supabase/requestAuth";
+
+interface RouteContext {
+  params: Promise<{
+    eventId: string;
+    threadId: string;
+    commentId: string;
+  }>;
+}
+
+const CONTEXT = "community.rooms.threads.comments.[commentId]";
+
+function getServiceClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return null;
+  return createServiceClient(supabaseUrl, serviceRoleKey);
+}
+
+function notFoundResponse(error: CommunityRoomThreadNotFoundError) {
+  return NextResponse.json(
+    { success: false, error: error.message },
+    { status: 404 },
+  );
+}
+
+export async function PATCH(request: Request, { params }: RouteContext) {
+  try {
+    const { eventId, threadId, commentId } = await params;
+    if (
+      !isValidUuid(eventId) ||
+      !isValidUuid(threadId) ||
+      !isValidUuid(commentId)
+    ) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const writeClient = getServiceClient();
+    if (!writeClient) return serviceUnavailable();
+
+    const rateLimitResponse = await gateMutation(
+      "comment-update",
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return invalidRequest("Invalid request body.");
+    }
+
+    const parsed =
+      mobileCommunityRoomThreadCommentEditDraftSchema.safeParse(json);
+    if (!parsed.success) {
+      return invalidRequest(
+        parsed.error.issues[0]?.message ?? "Invalid comment draft.",
+      );
+    }
+
+    const comment = await CommunityRoomThreadService.updateComment({
+      eventId,
+      threadId,
+      commentId,
+      authorId: authContext.user.id,
+      draft: parsed.data,
+      writeClient,
+    });
+
+    return NextResponse.json({ success: true, data: comment });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return notFoundResponse(error);
+    }
+    return genericFailure(CONTEXT, "Failed to update comment.", error);
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteContext) {
+  try {
+    const { eventId, threadId, commentId } = await params;
+    if (
+      !isValidUuid(eventId) ||
+      !isValidUuid(threadId) ||
+      !isValidUuid(commentId)
+    ) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const writeClient = getServiceClient();
+    if (!writeClient) return serviceUnavailable();
+
+    const rateLimitResponse = await gateMutation(
+      "comment-delete",
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    await CommunityRoomThreadService.deleteComment({
+      eventId,
+      threadId,
+      commentId,
+      authorId: authContext.user.id,
+      writeClient,
+    });
+
+    return NextResponse.json({ success: true, data: { id: commentId } });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return notFoundResponse(error);
+    }
+    return genericFailure(CONTEXT, "Failed to delete comment.", error);
+  }
+}

--- a/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { mobileCommunityRoomThreadCommentDraftSchema } from "@kurecal/domain";
+
+import { gateMutation } from "@/lib/api/mobileMutationRateLimit";
+import {
+  authRequired,
+  genericFailure,
+  invalidRequest,
+  serviceUnavailable,
+} from "@/lib/api/mobileResponses";
+import { isValidUuid } from "@/lib/uuid";
+import {
+  CommunityRoomThreadNotFoundError,
+  CommunityRoomThreadService,
+} from "@/services/communityRoomThreadService";
+import { createServiceClient } from "@/utils/supabase/service";
+import { getAuthenticatedRequestContext } from "@/utils/supabase/requestAuth";
+
+const CONTEXT = "community.rooms.threads.comments";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string; threadId: string }> },
+) {
+  try {
+    const { eventId, threadId } = await params;
+    if (!isValidUuid(eventId) || !isValidUuid(threadId)) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) return serviceUnavailable();
+
+    const rateLimitResponse = await gateMutation(
+      "comment-create",
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return invalidRequest("Invalid request body.");
+    }
+
+    const parsed = mobileCommunityRoomThreadCommentDraftSchema.safeParse(json);
+    if (!parsed.success) {
+      return invalidRequest(
+        parsed.error.issues[0]?.message ?? "Invalid comment draft.",
+      );
+    }
+
+    // If the draft includes a parentCommentId, validate it's a UUID before
+    // letting Postgres throw a generic cast error.
+    if (
+      parsed.data.parentCommentId != null &&
+      !isValidUuid(parsed.data.parentCommentId)
+    ) {
+      return invalidRequest();
+    }
+
+    const writeClient = createServiceClient(supabaseUrl, serviceRoleKey);
+
+    const comment = await CommunityRoomThreadService.createComment({
+      eventId,
+      threadId,
+      authorId: authContext.user.id,
+      draft: parsed.data,
+      writeClient,
+    });
+
+    return NextResponse.json(
+      { success: true, data: comment },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    return genericFailure(CONTEXT, "Failed to post comment.", error);
+  }
+}

--- a/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/comments/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { mobileCommunityRoomThreadCommentDraftSchema } from "@kurecal/domain";
+import {
+  mobileCommunityRoomCommentSortSchema,
+  mobileCommunityRoomThreadCommentDraftSchema,
+} from "@kurecal/domain";
 
 import { gateMutation } from "@/lib/api/mobileMutationRateLimit";
 import {
@@ -17,6 +20,56 @@ import { createServiceClient } from "@/utils/supabase/service";
 import { getAuthenticatedRequestContext } from "@/utils/supabase/requestAuth";
 
 const CONTEXT = "community.rooms.threads.comments";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string; threadId: string }> },
+) {
+  try {
+    const { eventId, threadId } = await params;
+    if (!isValidUuid(eventId) || !isValidUuid(threadId)) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) return serviceUnavailable();
+
+    const url = new URL(request.url);
+    const sortRaw = url.searchParams.get("sort");
+    const sortParsed = sortRaw
+      ? mobileCommunityRoomCommentSortSchema.safeParse(sortRaw)
+      : null;
+    const limitRaw = url.searchParams.get("limit");
+    const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+
+    const readClient = createServiceClient(supabaseUrl, serviceRoleKey);
+    const page = await CommunityRoomThreadService.getThreadCommentsPage({
+      eventId,
+      threadId,
+      viewerId: authContext.user.id,
+      readClient,
+      sort: sortParsed?.success ? sortParsed.data : undefined,
+      cursor: url.searchParams.get("cursor"),
+      limit: Number.isFinite(limit) ? limit : undefined,
+    });
+
+    return NextResponse.json({ success: true, data: page });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 404 },
+      );
+    }
+    return genericFailure(CONTEXT, "Failed to load comments.", error);
+  }
+}
 
 export async function POST(
   request: Request,

--- a/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/threads/[threadId]/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  mobileCommunityRoomCommentSortSchema,
+  mobileCommunityRoomThreadEditDraftSchema,
+} from "@kurecal/domain";
+
+import { gateMutation } from "@/lib/api/mobileMutationRateLimit";
+import {
+  authRequired,
+  genericFailure,
+  invalidRequest,
+  serviceUnavailable,
+} from "@/lib/api/mobileResponses";
+import { isValidUuid } from "@/lib/uuid";
+import {
+  CommunityRoomThreadNotFoundError,
+  CommunityRoomThreadService,
+} from "@/services/communityRoomThreadService";
+import { createServiceClient } from "@/utils/supabase/service";
+import { getAuthenticatedRequestContext } from "@/utils/supabase/requestAuth";
+
+interface RouteContext {
+  params: Promise<{ eventId: string; threadId: string }>;
+}
+
+const CONTEXT = "community.rooms.threads.[threadId]";
+
+function getServiceClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return null;
+  return createServiceClient(supabaseUrl, serviceRoleKey);
+}
+
+function notFoundResponse(error: CommunityRoomThreadNotFoundError) {
+  return NextResponse.json(
+    { success: false, error: error.message },
+    { status: 404 },
+  );
+}
+
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    const { eventId, threadId } = await params;
+    if (!isValidUuid(eventId) || !isValidUuid(threadId)) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const readClient = getServiceClient();
+    if (!readClient) return serviceUnavailable();
+
+    const url = new URL(request.url);
+    const sortRaw = url.searchParams.get("sort");
+    const sortParsed = sortRaw
+      ? mobileCommunityRoomCommentSortSchema.safeParse(sortRaw)
+      : null;
+    const sort = sortParsed?.success ? sortParsed.data : undefined;
+
+    const data = await CommunityRoomThreadService.getThreadDetail({
+      eventId,
+      threadId,
+      viewerId: authContext.user.id,
+      readClient,
+      sort,
+    });
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return notFoundResponse(error);
+    }
+    return genericFailure(CONTEXT, "Failed to load thread.", error);
+  }
+}
+
+export async function PATCH(request: Request, { params }: RouteContext) {
+  try {
+    const { eventId, threadId } = await params;
+    if (!isValidUuid(eventId) || !isValidUuid(threadId)) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const writeClient = getServiceClient();
+    if (!writeClient) return serviceUnavailable();
+
+    const rateLimitResponse = await gateMutation(
+      "thread-update",
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return invalidRequest("Invalid request body.");
+    }
+
+    const parsed = mobileCommunityRoomThreadEditDraftSchema.safeParse(json);
+    if (!parsed.success) {
+      return invalidRequest(
+        parsed.error.issues[0]?.message ?? "Invalid thread draft.",
+      );
+    }
+
+    const thread = await CommunityRoomThreadService.updateThread({
+      eventId,
+      threadId,
+      authorId: authContext.user.id,
+      draft: parsed.data,
+      writeClient,
+    });
+
+    return NextResponse.json({ success: true, data: thread });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return notFoundResponse(error);
+    }
+    return genericFailure(CONTEXT, "Failed to update thread.", error);
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteContext) {
+  try {
+    const { eventId, threadId } = await params;
+    if (!isValidUuid(eventId) || !isValidUuid(threadId)) {
+      return invalidRequest();
+    }
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const writeClient = getServiceClient();
+    if (!writeClient) return serviceUnavailable();
+
+    const rateLimitResponse = await gateMutation(
+      "thread-delete",
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    await CommunityRoomThreadService.deleteThread({
+      eventId,
+      threadId,
+      authorId: authContext.user.id,
+      writeClient,
+    });
+
+    return NextResponse.json({ success: true, data: { id: threadId } });
+  } catch (error) {
+    if (error instanceof CommunityRoomThreadNotFoundError) {
+      return notFoundResponse(error);
+    }
+    return genericFailure(CONTEXT, "Failed to delete thread.", error);
+  }
+}

--- a/src/app/api/mobile/community/rooms/[eventId]/threads/route.ts
+++ b/src/app/api/mobile/community/rooms/[eventId]/threads/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { mobileCommunityRoomThreadDraftSchema } from "@kurecal/domain";
+
+import { gateMutation } from "@/lib/api/mobileMutationRateLimit";
+import {
+  authRequired,
+  genericFailure,
+  invalidRequest,
+  serviceUnavailable,
+} from "@/lib/api/mobileResponses";
+import { isValidUuid } from "@/lib/uuid";
+import { CommunityRoomThreadService } from "@/services/communityRoomThreadService";
+import { createServiceClient } from "@/utils/supabase/service";
+import { getAuthenticatedRequestContext } from "@/utils/supabase/requestAuth";
+
+const CONTEXT = "community.rooms.threads";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string }> },
+) {
+  try {
+    const { eventId } = await params;
+    if (!isValidUuid(eventId)) return invalidRequest();
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) return serviceUnavailable();
+
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get("cursor");
+    const limitParam = url.searchParams.get("limit");
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+
+    const readClient = createServiceClient(supabaseUrl, serviceRoleKey);
+
+    const data = await CommunityRoomThreadService.listThreads({
+      eventId,
+      viewerId: authContext.user.id,
+      readClient,
+      cursor: cursor ?? undefined,
+      limit:
+        typeof limit === "number" && Number.isFinite(limit) ? limit : undefined,
+    });
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    return genericFailure(CONTEXT, "Failed to load threads.", error);
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string }> },
+) {
+  try {
+    const { eventId } = await params;
+    if (!isValidUuid(eventId)) return invalidRequest();
+
+    const authContext = await getAuthenticatedRequestContext(
+      request as NextRequest,
+    );
+    if (!authContext) return authRequired();
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) return serviceUnavailable();
+
+    const rateLimitResponse = await gateMutation(
+      "thread-create",
+      authContext.user.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return invalidRequest("Invalid request body.");
+    }
+
+    const parsed = mobileCommunityRoomThreadDraftSchema.safeParse(json);
+    if (!parsed.success) {
+      return invalidRequest(
+        parsed.error.issues[0]?.message ?? "Invalid thread draft.",
+      );
+    }
+
+    const writeClient = createServiceClient(supabaseUrl, serviceRoleKey);
+
+    const thread = await CommunityRoomThreadService.createThread({
+      eventId,
+      authorId: authContext.user.id,
+      draft: parsed.data,
+      writeClient,
+    });
+
+    return NextResponse.json({ success: true, data: thread }, { status: 201 });
+  } catch (error) {
+    return genericFailure(CONTEXT, "Failed to create thread.", error);
+  }
+}

--- a/src/lib/api/mobileMutationRateLimit.ts
+++ b/src/lib/api/mobileMutationRateLimit.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import {
+  checkRateLimit,
+  createRateLimiter,
+  RATE_LIMIT_CONFIGS,
+} from "@/utils/rateLimit";
+
+export type MutationScope =
+  | "thread-create"
+  | "thread-update"
+  | "thread-delete"
+  | "comment-create"
+  | "comment-update"
+  | "comment-delete"
+  | "community-report";
+
+// All current configs use a 1-minute window, so 60 is the worst-case retry
+// hint. We keep this constant rather than reading from the upstash response
+// because `checkRateLimit` already discards the reset timestamp.
+const DEFAULT_RETRY_AFTER_SECONDS = 60;
+
+/**
+ * Apply a sliding-window rate limit per user to a mutating community route.
+ * Returns a 429 NextResponse to return early, or null when the request is
+ * within the limit and the handler may proceed.
+ */
+export async function gateMutation(
+  scope: MutationScope,
+  userId: string,
+): Promise<NextResponse | null> {
+  const limiter = createRateLimiter(scope, "MEDIUM_FREQUENCY");
+  const result = await checkRateLimit(limiter, userId);
+  if (result.success) return null;
+
+  // Touch the config so any future tweak surfaces here.
+  void RATE_LIMIT_CONFIGS.MEDIUM_FREQUENCY;
+
+  const message =
+    typeof result.error === "object" &&
+    result.error !== null &&
+    "message" in result.error &&
+    typeof (result.error as { message: unknown }).message === "string"
+      ? (result.error as { message: string }).message
+      : "Too many requests. Please try again later.";
+
+  return NextResponse.json(
+    { success: false, error: message },
+    {
+      status: 429,
+      headers: { "Retry-After": String(DEFAULT_RETRY_AFTER_SECONDS) },
+    },
+  );
+}

--- a/src/lib/api/mobileResponses.ts
+++ b/src/lib/api/mobileResponses.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+export function invalidRequest(message = "Invalid request.") {
+  return NextResponse.json(
+    { success: false, error: message },
+    { status: 400 },
+  );
+}
+
+export function authRequired() {
+  return NextResponse.json(
+    { success: false, error: "Authentication required" },
+    { status: 401 },
+  );
+}
+
+export function serviceUnavailable() {
+  return NextResponse.json(
+    { success: false, error: "Community service is not configured." },
+    { status: 500 },
+  );
+}
+
+/**
+ * Log the raw error server-side and respond with a generic message so we
+ * don't leak Supabase/Postgres internals (constraint names, RLS reasons,
+ * table existence) to the API client.
+ */
+export function genericFailure(
+  context: string,
+  fallback: string,
+  error: unknown,
+) {
+  console.error(`[${context}] ${fallback}`, error);
+  return NextResponse.json(
+    { success: false, error: fallback },
+    { status: 500 },
+  );
+}

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,12 @@
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Lightweight UUID v4-ish syntactic check. Used at API route boundaries to
+ * reject obviously-malformed identifiers before they reach the database
+ * layer (which would otherwise throw a generic cast error and leak
+ * implementation details to the client).
+ */
+export function isValidUuid(value: string | null | undefined): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}

--- a/src/services/__tests__/communityRoomThreadService.test.ts
+++ b/src/services/__tests__/communityRoomThreadService.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CommunityRoomThreadService } from "@/services/communityRoomThreadService";
+
+const mocks = vi.hoisted(() => ({
+  getBlockedUserIdsForViewer: vi.fn(),
+}));
+
+vi.mock("@/services/blockService", () => ({
+  BlockService: {
+    getBlockedUserIdsForViewer: (...args: unknown[]) =>
+      mocks.getBlockedUserIdsForViewer(...args),
+  },
+}));
+
+function createAwaitableChain<T>(result: T) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> & PromiseLike<T> =
+    {} as never;
+
+  for (const method of [
+    "select",
+    "eq",
+    "is",
+    "order",
+    "limit",
+    "or",
+    "in",
+  ]) {
+    chain[method] = vi.fn(() => chain);
+  }
+
+  chain.maybeSingle = vi.fn(async () => result);
+  chain.then = vi.fn((onFulfilled, onRejected) =>
+    Promise.resolve(result).then(onFulfilled, onRejected),
+  );
+
+  return chain;
+}
+
+function profile(id: string, username: string) {
+  return {
+    id,
+    username,
+    full_name: username,
+    avatar_url: null,
+    headline: null,
+  };
+}
+
+function comment({
+  id,
+  authorId,
+  parentId = null,
+  createdAt,
+}: {
+  id: string;
+  authorId: string;
+  parentId?: string | null;
+  createdAt: string;
+}) {
+  return {
+    id,
+    thread_id: "thread-1",
+    author_id: authorId,
+    body: `body-${id}`,
+    created_at: createdAt,
+    parent_comment_id: parentId,
+    deleted_at: null,
+    edited_at: null,
+  };
+}
+
+describe("CommunityRoomThreadService comment pagination", () => {
+  it("returns cursor metadata and preserves root comment branches", async () => {
+    mocks.getBlockedUserIdsForViewer.mockResolvedValue(new Set());
+
+    const rootOne = comment({
+      id: "root-1",
+      authorId: "author-1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const rootTwo = comment({
+      id: "root-2",
+      authorId: "author-2",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    const rootThree = comment({
+      id: "root-3",
+      authorId: "author-3",
+      createdAt: "2026-01-03T00:00:00.000Z",
+    });
+    const reply = comment({
+      id: "reply-1",
+      authorId: "author-3",
+      parentId: "root-1",
+      createdAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    const threadChain = createAwaitableChain({
+      data: { author_id: "author-1", deleted_at: null },
+      error: null,
+    });
+    const rootsChain = createAwaitableChain({
+      data: [rootOne, rootTwo, rootThree],
+      error: null,
+    });
+    const repliesChain = createAwaitableChain({
+      data: [reply],
+      error: null,
+    });
+    const profilesChain = createAwaitableChain({
+      data: [
+        profile("author-1", "one"),
+        profile("author-2", "two"),
+        profile("author-3", "three"),
+      ],
+      error: null,
+    });
+    const commentChains = [rootsChain, repliesChain];
+    const readClient = {
+      from: vi.fn((table: string) => {
+        if (table === "event_room_threads") return threadChain;
+        if (table === "event_room_thread_comments") {
+          const next = commentChains.shift();
+          if (!next) throw new Error("unexpected comments query");
+          return next;
+        }
+        if (table === "profiles") return profilesChain;
+        throw new Error(`unexpected table ${table}`);
+      }),
+    };
+
+    const page = await CommunityRoomThreadService.getThreadCommentsPage({
+      threadId: "thread-1",
+      viewerId: "viewer-1",
+      readClient: readClient as never,
+      limit: 2,
+      sort: "oldest",
+    });
+
+    expect(page.hasMore).toBe(true);
+    expect(page.loadedCount).toBe(3);
+    expect(page.nextCursor).toBeTruthy();
+    expect(
+      JSON.parse(Buffer.from(page.nextCursor!, "base64url").toString("utf8")),
+    ).toEqual({
+      id: "root-2",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    expect(page.comments.map((item) => item.id)).toEqual(["root-1", "root-2"]);
+    expect(page.comments[0]?.replies.map((item) => item.id)).toEqual([
+      "reply-1",
+    ]);
+    expect(page.comments[1]?.replies).toEqual([]);
+    expect(repliesChain.in).toHaveBeenCalledWith("parent_comment_id", [
+      "root-1",
+      "root-2",
+    ]);
+  });
+});

--- a/src/services/communityModerationService.ts
+++ b/src/services/communityModerationService.ts
@@ -25,6 +25,18 @@ interface ProfileSubjectRow {
   community_moderation_status: 'active' | 'restricted' | 'removed';
 }
 
+interface EventThreadSubjectRow {
+  id: string;
+  author_id: string;
+  deleted_at: string | null;
+}
+
+interface EventThreadCommentSubjectRow {
+  id: string;
+  author_id: string;
+  deleted_at: string | null;
+}
+
 export const COMMUNITY_ACCESS_RESTRICTED_ERROR =
   'Your community access is currently limited.';
 export const REMOVED_POST_PLACEHOLDER = 'This post was removed by moderators.';
@@ -80,6 +92,15 @@ export class CommunityModerationService {
       subject.community_moderation_status === 'removed'
     ) {
       throw new Error('This member is already unavailable in community.');
+    }
+
+    if (
+      (payload.subjectType === 'event_thread' ||
+        payload.subjectType === 'event_thread_comment') &&
+      'deleted_at' in subject &&
+      subject.deleted_at !== null
+    ) {
+      throw new Error('This content is already unavailable in community.');
     }
   }
 
@@ -176,12 +197,54 @@ export class CommunityModerationService {
       return;
     }
 
+    if (params.subjectType === 'event_thread') {
+      await this.removeEventThread(params.subjectId, supabase);
+      return;
+    }
+
+    if (params.subjectType === 'event_thread_comment') {
+      await this.removeEventThreadComment(params.subjectId, supabase);
+      return;
+    }
+
     await this.removeProfile(
       params.subjectId,
       params.reviewerId,
       params.resolutionNotes,
       supabase
     );
+  }
+
+  private static async removeEventThread(
+    threadId: string,
+    supabase: SupabaseClientType
+  ): Promise<void> {
+    const { error } = await (supabase as any)
+      .from('event_room_threads')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', threadId)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new Error(error.message ?? 'Failed to remove the reported thread.');
+    }
+  }
+
+  private static async removeEventThreadComment(
+    commentId: string,
+    supabase: SupabaseClientType
+  ): Promise<void> {
+    const { error } = await (supabase as any)
+      .from('event_room_thread_comments')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', commentId)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new Error(
+        error.message ?? 'Failed to remove the reported comment.',
+      );
+    }
   }
 
   private static async removePost(
@@ -265,7 +328,46 @@ export class CommunityModerationService {
     subjectType: SubjectType,
     subjectId: string,
     supabase: SupabaseClientType
-  ): Promise<PostSubjectRow | CommentSubjectRow | ProfileSubjectRow | null> {
+  ): Promise<
+    | PostSubjectRow
+    | CommentSubjectRow
+    | ProfileSubjectRow
+    | EventThreadSubjectRow
+    | EventThreadCommentSubjectRow
+    | null
+  > {
+    if (subjectType === 'event_thread') {
+      const { data, error } = await (supabase as any)
+        .from('event_room_threads')
+        .select('id, author_id, deleted_at')
+        .eq('id', subjectId)
+        .maybeSingle();
+
+      if (error) {
+        throw new Error(
+          error.message ?? 'Unable to load the reported thread.',
+        );
+      }
+
+      return (data as EventThreadSubjectRow | null) ?? null;
+    }
+
+    if (subjectType === 'event_thread_comment') {
+      const { data, error } = await (supabase as any)
+        .from('event_room_thread_comments')
+        .select('id, author_id, deleted_at')
+        .eq('id', subjectId)
+        .maybeSingle();
+
+      if (error) {
+        throw new Error(
+          error.message ?? 'Unable to load the reported comment.',
+        );
+      }
+
+      return (data as EventThreadCommentSubjectRow | null) ?? null;
+    }
+
     if (subjectType === 'post') {
       const { data, error } = await supabase
         .from('circle_posts')

--- a/src/services/communityReportService.ts
+++ b/src/services/communityReportService.ts
@@ -9,7 +9,12 @@ import { CommunityModerationService } from '@/services/communityModerationServic
 interface CommunityReportRow {
   id: string;
   reporter_id: string;
-  subject_type: 'post' | 'comment' | 'profile';
+  subject_type:
+    | 'post'
+    | 'comment'
+    | 'profile'
+    | 'event_thread'
+    | 'event_thread_comment';
   subject_id: string;
   reason: CommunityReportInput['reason'];
   details: string | null;

--- a/src/services/communityRoomService.ts
+++ b/src/services/communityRoomService.ts
@@ -1,0 +1,521 @@
+import type {
+  MobileCommunityRoomAttendee,
+  MobileCommunityRoomDetail,
+  MobileCommunityRoomRelationship,
+  MobileCommunityRoomSignal,
+  MobileCommunityRoomSignalKind,
+} from "@kurecal/domain";
+
+import { BlockService } from "@/services/blockService";
+import type { SupabaseClientType } from "@/types";
+
+const ACTIVE_NOW_WINDOW_MS = 24 * 60 * 60 * 1000;
+const SIGNAL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const SIGNAL_LIMIT = 8;
+
+// Casts the typed Supabase client to a loosely-typed builder so we can query
+// tables that haven't been regenerated into the Database types yet
+// (event_room_threads ships in migration 20260515_event_room_threads.sql).
+// Remove once `supabase gen types` has been re-run.
+function untypedClient(client: SupabaseClientType): any {
+  return client as any;
+}
+
+interface EventRow {
+  id: string;
+  slug: string;
+  title: string | null;
+  start_time: string;
+  end_time: string | null;
+  event_image_url: string | null;
+  source_url: string | null;
+  location: string | null;
+  event_format: string | null;
+  status: string;
+}
+
+interface AttendanceRow {
+  user_id: string;
+  status: string;
+  is_bookmarked: boolean;
+  created_at: string | null;
+}
+
+interface ProfileRow {
+  id: string;
+  full_name: string | null;
+  username: string | null;
+  avatar_url: string | null;
+  headline: string | null;
+  location: string | null;
+  profile_visibility: string | null;
+  show_attendance: boolean | null;
+}
+
+interface CareerProfileRow {
+  user_id: string;
+  current_role: string | null;
+  industry: string | null;
+  company_size: string | null;
+}
+
+interface ViewerProfileRow {
+  show_attendance: boolean | null;
+  profile_visibility: string | null;
+  username: string | null;
+}
+
+interface ViewerEventRow {
+  status: string | null;
+  is_bookmarked: boolean | null;
+}
+
+export class CommunityRoomNotFoundError extends Error {
+  constructor(eventId: string) {
+    super(`Room not found for event ${eventId}`);
+    this.name = "CommunityRoomNotFoundError";
+  }
+}
+
+export class CommunityRoomService {
+  static async getRoomDetail({
+    viewerId,
+    eventId,
+    readClient,
+    now = new Date(),
+  }: {
+    viewerId: string;
+    eventId: string;
+    readClient: SupabaseClientType;
+    now?: Date;
+  }): Promise<MobileCommunityRoomDetail> {
+    const eventResult = await readClient
+      .from("events")
+      .select(
+        "id, slug, title, start_time, end_time, event_image_url, source_url, location, event_format, status",
+      )
+      .eq("id", eventId)
+      .eq("status", "confirmed")
+      .maybeSingle();
+
+    if (eventResult.error) {
+      throw new Error("Failed to load room event.");
+    }
+
+    const event = (eventResult.data || null) as EventRow | null;
+    if (!event) {
+      throw new CommunityRoomNotFoundError(eventId);
+    }
+
+    const [
+      viewerProfileResult,
+      viewerEventResult,
+      attendanceResult,
+      threadCountResult,
+    ] = await Promise.all([
+      readClient
+        .from("profiles")
+        .select("show_attendance, profile_visibility, username")
+        .eq("id", viewerId)
+        .maybeSingle(),
+      readClient
+        .from("user_events")
+        .select("status, is_bookmarked")
+        .eq("event_id", eventId)
+        .eq("user_id", viewerId)
+        .maybeSingle(),
+      readClient
+        .from("user_events")
+        .select("user_id, status, is_bookmarked, created_at")
+        .eq("event_id", eventId)
+        .in("status", ["attending", "attended"]),
+      untypedClient(readClient)
+        .from("event_room_threads")
+        .select("id", { count: "exact", head: true })
+        .eq("event_id", eventId),
+    ]);
+
+    if (
+      viewerProfileResult.error ||
+      viewerEventResult.error ||
+      attendanceResult.error
+    ) {
+      throw new Error("Failed to load room context.");
+    }
+
+    const threadCountRaw = threadCountResult as {
+      count: number | null;
+      error: unknown;
+    };
+    const threadCount = threadCountRaw.error
+      ? 0
+      : Math.max(0, threadCountRaw.count ?? 0);
+
+    const viewerProfile = (viewerProfileResult.data || null) as
+      | ViewerProfileRow
+      | null;
+    const viewerEvent = (viewerEventResult.data || null) as
+      | ViewerEventRow
+      | null;
+
+    const isAttending =
+      viewerEvent?.status === "attending" || viewerEvent?.status === "attended";
+    const isSaved = Boolean(viewerEvent?.is_bookmarked) || isAttending;
+    const isVisible =
+      isAttending &&
+      viewerProfile?.profile_visibility === "public" &&
+      viewerProfile?.show_attendance === true &&
+      Boolean(viewerProfile?.username);
+
+    const attendanceRows = ((attendanceResult.data ||
+      []) as AttendanceRow[]).filter((row) => row.user_id !== viewerId);
+
+    const attendanceByUserId = new Map<string, AttendanceRow>();
+    for (const row of attendanceRows) {
+      if (!attendanceByUserId.has(row.user_id)) {
+        attendanceByUserId.set(row.user_id, row);
+      }
+    }
+
+    const totalAttendeeCount = attendanceByUserId.size;
+    const candidateUserIds = Array.from(attendanceByUserId.keys());
+
+    if (candidateUserIds.length === 0) {
+      return {
+        event: shapeEvent(event),
+        viewer: { isAttending, isSaved, isVisible },
+        stats: {
+          totalAttendeeCount: 0,
+          visibleAttendeeCount: 0,
+          networkAttendingCount: 0,
+          activeNowCount: 0,
+          threadCount,
+        },
+        attendees: [],
+        signals: [],
+      };
+    }
+
+    const blockedIds = await BlockService.getBlockedUserIdsForViewer(
+      viewerId,
+      candidateUserIds,
+      readClient,
+    );
+    const visibleCandidateIds = candidateUserIds.filter(
+      (id) => !blockedIds.has(id),
+    );
+
+    if (visibleCandidateIds.length === 0) {
+      return {
+        event: shapeEvent(event),
+        viewer: { isAttending, isSaved, isVisible },
+        stats: {
+          totalAttendeeCount,
+          visibleAttendeeCount: 0,
+          networkAttendingCount: 0,
+          activeNowCount: 0,
+          threadCount,
+        },
+        attendees: [],
+        signals: [],
+      };
+    }
+
+    const [
+      profilesResult,
+      careerProfilesResult,
+      viewerFollowingResult,
+      followedByResult,
+    ] = await Promise.all([
+      readClient
+        .from("profiles")
+        .select(
+          "id, full_name, avatar_url, username, headline, location, profile_visibility, show_attendance",
+        )
+        .in("id", visibleCandidateIds),
+      readClient
+        .from("career_profiles")
+        .select("user_id, current_role, industry, company_size")
+        .in("user_id", visibleCandidateIds),
+      readClient
+        .from("follows")
+        .select("following_id")
+        .eq("follower_id", viewerId)
+        .in("following_id", visibleCandidateIds),
+      readClient
+        .from("follows")
+        .select("follower_id")
+        .eq("following_id", viewerId)
+        .in("follower_id", visibleCandidateIds),
+    ]);
+
+    if (
+      profilesResult.error ||
+      careerProfilesResult.error ||
+      viewerFollowingResult.error ||
+      followedByResult.error
+    ) {
+      throw new Error("Failed to load room attendee context.");
+    }
+
+    const profilesById = new Map<string, ProfileRow>(
+      ((profilesResult.data || []) as ProfileRow[]).map((row) => [row.id, row]),
+    );
+    const careerProfilesById = new Map<string, CareerProfileRow>(
+      ((careerProfilesResult.data || []) as CareerProfileRow[]).map((row) => [
+        row.user_id,
+        row,
+      ]),
+    );
+    const followingIds = new Set<string>(
+      ((viewerFollowingResult.data || []) as Array<{ following_id: string }>)
+        .map((row) => row.following_id),
+    );
+    const followedByIds = new Set<string>(
+      ((followedByResult.data || []) as Array<{ follower_id: string }>).map(
+        (row) => row.follower_id,
+      ),
+    );
+
+    const mutualConnectionsCountByUserId = await loadMutualConnectionCounts({
+      readClient,
+      viewerFollowingIds: followingIds,
+      candidateIds: visibleCandidateIds,
+    });
+
+    const attendees: MobileCommunityRoomAttendee[] = [];
+    let visibleAttendeeCount = 0;
+    let networkAttendingCount = 0;
+    const nowMs = now.getTime();
+    const activeWindowCutoff = nowMs - ACTIVE_NOW_WINDOW_MS;
+    let activeNowCount = 0;
+
+    for (const userId of visibleCandidateIds) {
+      const profile = profilesById.get(userId);
+      const attendance = attendanceByUserId.get(userId);
+      if (!profile || !profile.username || !attendance) {
+        continue;
+      }
+
+      const isInNetwork = followingIds.has(userId);
+      const followsViewer = followedByIds.has(userId);
+      const isMutualFollow = isInNetwork && followsViewer;
+      if (isInNetwork) {
+        networkAttendingCount += 1;
+      }
+
+      const isAttendeeVisible =
+        profile.profile_visibility === "public" &&
+        profile.show_attendance === true;
+      if (!isAttendeeVisible) {
+        continue;
+      }
+
+      const createdAtMs = attendance.created_at
+        ? new Date(attendance.created_at).getTime()
+        : 0;
+      if (createdAtMs >= activeWindowCutoff) {
+        activeNowCount += 1;
+      }
+
+      const career = careerProfilesById.get(userId);
+      const relationship = computeRelationship({
+        isInNetwork,
+        followsViewer,
+        isMutualFollow,
+      });
+
+      attendees.push({
+        id: profile.id,
+        fullName: profile.full_name,
+        username: profile.username,
+        avatarUrl: profile.avatar_url,
+        headline: profile.headline,
+        currentRole: career?.current_role ?? null,
+        industry: career?.industry ?? null,
+        location: profile.location,
+        isInNetwork,
+        followsViewer,
+        isMutualFollow,
+        mutualConnectionsCount:
+          mutualConnectionsCountByUserId.get(userId) ?? 0,
+        relationship,
+        matchReason: buildMatchReason({
+          relationship,
+          currentRole: career?.current_role ?? null,
+          location: profile.location,
+        }),
+      });
+      visibleAttendeeCount += 1;
+    }
+
+    attendees.sort(compareAttendees);
+
+    const signalCutoff = nowMs - SIGNAL_WINDOW_MS;
+    const signals: MobileCommunityRoomSignal[] = [];
+    for (const userId of visibleCandidateIds) {
+      const profile = profilesById.get(userId);
+      const attendance = attendanceByUserId.get(userId);
+      if (!profile || !profile.username || !attendance) continue;
+      if (
+        profile.profile_visibility !== "public" ||
+        profile.show_attendance !== true
+      ) {
+        continue;
+      }
+      const createdAtMs = attendance.created_at
+        ? new Date(attendance.created_at).getTime()
+        : 0;
+      if (createdAtMs < signalCutoff) continue;
+
+      const isInNetwork = followingIds.has(userId);
+      const isMutualFollow = isInNetwork && followedByIds.has(userId);
+
+      let kind: MobileCommunityRoomSignalKind = "joined_attending";
+      if (isMutualFollow) {
+        kind = "mutual_arrived";
+      } else if (attendance.is_bookmarked && attendance.status !== "attending") {
+        kind = "saved";
+      }
+
+      signals.push({
+        id: `${eventId}:${userId}`,
+        kind,
+        occurredAt: new Date(createdAtMs).toISOString(),
+        actor: {
+          id: profile.id,
+          fullName: profile.full_name,
+          username: profile.username,
+          avatarUrl: profile.avatar_url,
+        },
+      });
+    }
+
+    signals.sort(
+      (a, b) =>
+        new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime(),
+    );
+
+    return {
+      event: shapeEvent(event),
+      viewer: { isAttending, isSaved, isVisible },
+      stats: {
+        totalAttendeeCount,
+        visibleAttendeeCount,
+        networkAttendingCount,
+        activeNowCount,
+        threadCount,
+      },
+      attendees,
+      signals: signals.slice(0, SIGNAL_LIMIT),
+    };
+  }
+}
+
+async function loadMutualConnectionCounts({
+  readClient,
+  viewerFollowingIds,
+  candidateIds,
+}: {
+  readClient: SupabaseClientType;
+  viewerFollowingIds: Set<string>;
+  candidateIds: string[];
+}): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  if (viewerFollowingIds.size === 0 || candidateIds.length === 0) {
+    return counts;
+  }
+
+  const candidateFollowingResult = await readClient
+    .from("follows")
+    .select("follower_id, following_id")
+    .in("follower_id", candidateIds);
+
+  if (candidateFollowingResult.error) {
+    return counts;
+  }
+
+  for (const row of (candidateFollowingResult.data || []) as Array<{
+    follower_id: string;
+    following_id: string;
+  }>) {
+    if (!viewerFollowingIds.has(row.following_id)) continue;
+    counts.set(row.follower_id, (counts.get(row.follower_id) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+function shapeEvent(event: EventRow) {
+  return {
+    id: event.id,
+    slug: event.slug,
+    title: event.title || "Untitled event",
+    startTime: event.start_time,
+    endTime: event.end_time,
+    location: event.location,
+    format: normalizeFormat(event.event_format),
+    imageUrl: event.event_image_url,
+    sourceUrl: event.source_url,
+  };
+}
+
+function normalizeFormat(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function computeRelationship({
+  isInNetwork,
+  followsViewer,
+  isMutualFollow,
+}: {
+  isInNetwork: boolean;
+  followsViewer: boolean;
+  isMutualFollow: boolean;
+}): MobileCommunityRoomRelationship {
+  if (isMutualFollow) return "mutual";
+  if (followsViewer) return "follows_you";
+  if (isInNetwork) return "in_network";
+  return "stranger";
+}
+
+function buildMatchReason({
+  relationship,
+  currentRole,
+  location,
+}: {
+  relationship: MobileCommunityRoomRelationship;
+  currentRole: string | null;
+  location: string | null;
+}): string | null {
+  if (relationship === "mutual") return "Mutual follow";
+  if (relationship === "follows_you") return "Follows you";
+  if (relationship === "in_network") return "In your network";
+  if (currentRole) return currentRole;
+  if (location) return location;
+  return null;
+}
+
+const RELATIONSHIP_RANK: Record<MobileCommunityRoomRelationship, number> = {
+  mutual: 0,
+  follows_you: 1,
+  in_network: 2,
+  stranger: 3,
+};
+
+function compareAttendees(
+  left: MobileCommunityRoomAttendee,
+  right: MobileCommunityRoomAttendee,
+): number {
+  const orderDiff =
+    RELATIONSHIP_RANK[left.relationship] - RELATIONSHIP_RANK[right.relationship];
+  if (orderDiff !== 0) return orderDiff;
+  if (right.mutualConnectionsCount !== left.mutualConnectionsCount) {
+    return right.mutualConnectionsCount - left.mutualConnectionsCount;
+  }
+  const leftName = left.fullName || left.username;
+  const rightName = right.fullName || right.username;
+  return leftName.localeCompare(rightName);
+}

--- a/src/services/communityRoomThreadService.ts
+++ b/src/services/communityRoomThreadService.ts
@@ -3,6 +3,7 @@ import type {
   MobileCommunityRoomThread,
   MobileCommunityRoomThreadChildComment,
   MobileCommunityRoomThreadComment,
+  MobileCommunityRoomThreadCommentPage,
   MobileCommunityRoomThreadCommentDraft,
   MobileCommunityRoomThreadCommentEditDraft,
   MobileCommunityRoomThreadDetail,
@@ -16,7 +17,8 @@ import type { SupabaseClientType } from "@/types";
 
 const THREAD_LIST_DEFAULT_LIMIT = 20;
 const THREAD_LIST_MAX_LIMIT = 50;
-const COMMENT_LIST_LIMIT = 200;
+const COMMENT_PAGE_DEFAULT_LIMIT = 200;
+const COMMENT_PAGE_MAX_LIMIT = 200;
 
 // See communityRoomService.ts — event_room_threads isn't in the generated
 // Database types yet. Remove once `supabase gen types` has been re-run.
@@ -81,6 +83,40 @@ const COMMENT_COLUMNS =
 
 const DELETED_AUTHOR_ID = "00000000-0000-0000-0000-000000000000";
 const DELETED_BODY = "[deleted]";
+
+interface CommentCursor {
+  createdAt: string;
+  id: string;
+}
+
+function encodeCommentCursor(cursor: CommentCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeCommentCursor(value: string | null | undefined): CommentCursor | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (
+      typeof parsed?.createdAt === "string" &&
+      typeof parsed?.id === "string"
+    ) {
+      return { createdAt: parsed.createdAt, id: parsed.id };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function countRenderedComments(
+  comments: MobileCommunityRoomThreadComment[],
+): number {
+  return comments.reduce(
+    (total, comment) => total + 1 + comment.replies.length,
+    0,
+  );
+}
 
 function shapeThread(
   row: ThreadRow,
@@ -262,6 +298,210 @@ export class CommunityRoomThreadService {
     readClient: SupabaseClientType;
     sort?: MobileCommunityRoomCommentSort;
   }): Promise<MobileCommunityRoomThreadDetail> {
+    const { row, author } = await this.getThreadRowAndAuthor({
+      eventId,
+      threadId,
+      readClient,
+    });
+    const commentPage = await this.getThreadCommentsPage({
+      threadId,
+      viewerId,
+      threadAuthorId: row.author_id,
+      readClient,
+      sort,
+    });
+
+    return {
+      thread: shapeThread(row, author, viewerId),
+      comments: commentPage.comments,
+      commentPage,
+    };
+  }
+
+  static async getThreadCommentsPage({
+    eventId,
+    threadId,
+    viewerId,
+    threadAuthorId,
+    readClient,
+    sort = "oldest",
+    cursor,
+    limit = COMMENT_PAGE_DEFAULT_LIMIT,
+  }: {
+    eventId?: string;
+    threadId: string;
+    viewerId: string;
+    threadAuthorId?: string;
+    readClient: SupabaseClientType;
+    sort?: MobileCommunityRoomCommentSort;
+    cursor?: string | null;
+    limit?: number;
+  }): Promise<MobileCommunityRoomThreadCommentPage> {
+    let resolvedThreadAuthorId = threadAuthorId;
+    if (!resolvedThreadAuthorId) {
+      let threadQuery = untypedClient(readClient)
+        .from("event_room_threads")
+        .select("author_id, deleted_at")
+        .eq("id", threadId);
+      if (eventId) threadQuery = threadQuery.eq("event_id", eventId);
+      const threadResult = (await threadQuery.maybeSingle()) as {
+        data: { author_id: string; deleted_at: string | null } | null;
+        error: { message?: string } | null;
+      };
+      if (threadResult.error) {
+        fail("Failed to verify comment thread.", threadResult.error);
+      }
+      if (!threadResult.data || threadResult.data.deleted_at) {
+        throw new CommunityRoomThreadNotFoundError(threadId);
+      }
+      resolvedThreadAuthorId = threadResult.data.author_id;
+    }
+
+    const cappedLimit = Math.min(
+      Math.max(Math.floor(limit), 1),
+      COMMENT_PAGE_MAX_LIMIT,
+    );
+    const ascending = sort !== "newest";
+    const decodedCursor = decodeCommentCursor(cursor);
+
+    let rootsQuery = untypedClient(readClient)
+      .from("event_room_thread_comments")
+      .select(COMMENT_COLUMNS)
+      .eq("thread_id", threadId)
+      .is("parent_comment_id", null)
+      .order("created_at", { ascending })
+      .order("id", { ascending })
+      .limit(cappedLimit + 1);
+
+    if (decodedCursor) {
+      const operator = ascending ? "gt" : "lt";
+      rootsQuery = rootsQuery.or(
+        `created_at.${operator}.${decodedCursor.createdAt},and(created_at.eq.${decodedCursor.createdAt},id.${operator}.${decodedCursor.id})`,
+      );
+    }
+
+    const rootsResult = (await rootsQuery) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (rootsResult.error) {
+      fail("Failed to load thread comment roots.", rootsResult.error);
+    }
+
+    const rootRows = (rootsResult.data ?? []) as CommentRow[];
+    const hasMore = rootRows.length > cappedLimit;
+    const pageRoots = hasMore ? rootRows.slice(0, cappedLimit) : rootRows;
+    const rootIds = pageRoots.map((row) => row.id);
+
+    let commentRows = pageRoots;
+    if (rootIds.length > 0) {
+      const repliesResult = (await untypedClient(readClient)
+        .from("event_room_thread_comments")
+        .select(COMMENT_COLUMNS)
+        .eq("thread_id", threadId)
+        .in("parent_comment_id", rootIds)
+        .order("created_at", { ascending: true })) as {
+        data: unknown;
+        error: { message?: string } | null;
+      };
+
+      if (repliesResult.error) {
+        fail("Failed to load thread comment replies.", repliesResult.error);
+      }
+      commentRows = [...pageRoots, ...((repliesResult.data ?? []) as CommentRow[])];
+    }
+
+    const comments = await this.shapeCommentRows({
+      commentRows,
+      rootIds: new Set(rootIds),
+      threadAuthorId: resolvedThreadAuthorId,
+      viewerId,
+      readClient,
+      sort,
+      bubbleOrphans: false,
+    });
+
+    const nextRoot = hasMore ? pageRoots[pageRoots.length - 1] : null;
+    return {
+      comments,
+      nextCursor: nextRoot
+        ? encodeCommentCursor({ createdAt: nextRoot.created_at, id: nextRoot.id })
+        : null,
+      hasMore,
+      loadedCount: countRenderedComments(comments),
+    };
+  }
+
+  static async getThreadComment({
+    eventId,
+    threadId,
+    commentId,
+    viewerId,
+    readClient,
+  }: {
+    eventId?: string;
+    threadId: string;
+    commentId: string;
+    viewerId: string;
+    readClient: SupabaseClientType;
+  }): Promise<MobileCommunityRoomThreadComment> {
+    const commentResult = (await untypedClient(readClient)
+      .from("event_room_thread_comments")
+      .select(COMMENT_COLUMNS)
+      .eq("thread_id", threadId)
+      .eq("id", commentId)
+      .maybeSingle()) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (commentResult.error) {
+      fail("Failed to load thread comment.", commentResult.error);
+    }
+    if (!commentResult.data) {
+      throw new CommunityRoomThreadNotFoundError(commentId);
+    }
+
+    const commentRow = commentResult.data as CommentRow;
+    let threadQuery = untypedClient(readClient)
+      .from("event_room_threads")
+      .select("author_id")
+      .eq("id", threadId);
+    if (eventId) threadQuery = threadQuery.eq("event_id", eventId);
+    const threadResult = (await threadQuery.maybeSingle()) as {
+      data: { author_id: string } | null;
+      error: { message?: string } | null;
+    };
+    if (threadResult.error || !threadResult.data) {
+      fail("Failed to verify comment thread.", threadResult.error);
+    }
+
+    const comments = await this.shapeCommentRows({
+      commentRows: [commentRow],
+      rootIds: new Set(commentRow.parent_comment_id ? [] : [commentRow.id]),
+      threadAuthorId: threadResult.data.author_id,
+      viewerId,
+      readClient,
+      sort: "oldest",
+      bubbleOrphans: true,
+    });
+    const shaped = comments[0];
+    if (!shaped) {
+      throw new CommunityRoomThreadNotFoundError(commentId);
+    }
+    return shaped;
+  }
+
+  private static async getThreadRowAndAuthor({
+    eventId,
+    threadId,
+    readClient,
+  }: {
+    eventId: string;
+    threadId: string;
+    readClient: SupabaseClientType;
+  }): Promise<{ row: ThreadRow; author: AuthorProfileRow }> {
     const threadResult = (await untypedClient(readClient)
       .from("event_room_threads")
       .select(THREAD_COLUMNS)
@@ -280,36 +520,18 @@ export class CommunityRoomThreadService {
     }
 
     const row = threadResult.data as ThreadRow;
-
-    // Soft-deleted threads behave as if they no longer exist.
     if (row.deleted_at) {
       throw new CommunityRoomThreadNotFoundError(threadId);
     }
 
-    const [authorResult, commentsResult] = await Promise.all([
-      readClient
-        .from("profiles")
-        .select("id, full_name, avatar_url, username, headline")
-        .eq("id", row.author_id)
-        .maybeSingle(),
-      untypedClient(readClient)
-        .from("event_room_thread_comments")
-        .select(COMMENT_COLUMNS)
-        .eq("thread_id", threadId)
-        .order("created_at", { ascending: true })
-        .limit(COMMENT_LIST_LIMIT),
-    ]);
+    const authorResult = await readClient
+      .from("profiles")
+      .select("id, full_name, avatar_url, username, headline")
+      .eq("id", row.author_id)
+      .maybeSingle();
 
     if (authorResult.error || !authorResult.data) {
       throw new Error("Failed to load thread author.");
-    }
-
-    const commentsRaw = commentsResult as {
-      data: unknown;
-      error: { message?: string } | null;
-    };
-    if (commentsRaw.error) {
-      fail("Failed to load thread comments.", commentsRaw.error);
     }
 
     const author = authorResult.data as AuthorProfileRow;
@@ -317,7 +539,26 @@ export class CommunityRoomThreadService {
       throw new Error("Thread author profile is incomplete.");
     }
 
-    const commentRows = (commentsRaw.data ?? []) as CommentRow[];
+    return { row, author };
+  }
+
+  private static async shapeCommentRows({
+    commentRows,
+    rootIds,
+    threadAuthorId,
+    viewerId,
+    readClient,
+    sort,
+    bubbleOrphans,
+  }: {
+    commentRows: CommentRow[];
+    rootIds: Set<string>;
+    threadAuthorId: string;
+    viewerId: string;
+    readClient: SupabaseClientType;
+    sort: MobileCommunityRoomCommentSort;
+    bubbleOrphans: boolean;
+  }): Promise<MobileCommunityRoomThreadComment[]> {
     const commenterIds = Array.from(
       new Set(commentRows.map((c) => c.author_id)),
     );
@@ -339,15 +580,6 @@ export class CommunityRoomThreadService {
       }
     }
 
-    const threadAuthorId = row.author_id;
-    const rootIds = new Set(
-      commentRows.filter((c) => c.parent_comment_id === null).map((c) => c.id),
-    );
-
-    // Hide comments authored by users the viewer has blocked. We render the
-    // same tombstone we use for soft-deletes so tree structure is preserved
-    // (e.g. replies under a blocked author's parent stay visible) without
-    // leaking the blocked author's content or identity.
     const blockedIds =
       commenterIds.length > 0
         ? await BlockService.getBlockedUserIdsForViewer(
@@ -357,37 +589,27 @@ export class CommunityRoomThreadService {
           )
         : new Set<string>();
 
+    function baseDeleted(commentRow: CommentRow) {
+      return {
+        id: commentRow.id,
+        threadId: commentRow.thread_id,
+        body: DELETED_BODY,
+        createdAt: commentRow.deleted_at ?? commentRow.created_at,
+        author: maskedAuthor(),
+        isAuthor: false,
+        isOp: false,
+        isDeleted: true,
+        editedAt: null,
+      };
+    }
+
     function buildChild(
       commentRow: CommentRow,
     ): MobileCommunityRoomThreadChildComment | null {
-      if (commentRow.deleted_at) {
+      if (commentRow.deleted_at || blockedIds.has(commentRow.author_id)) {
         return {
-          id: commentRow.id,
-          threadId: commentRow.thread_id,
+          ...baseDeleted(commentRow),
           parentId: commentRow.parent_comment_id,
-          body: DELETED_BODY,
-          // Use the deletion timestamp so the original posting time isn't
-          // leaked to anyone who can request the thread after deletion.
-          createdAt: commentRow.deleted_at,
-          author: maskedAuthor(),
-          isAuthor: false,
-          isOp: false,
-          isDeleted: true,
-          editedAt: null,
-        };
-      }
-      if (blockedIds.has(commentRow.author_id)) {
-        return {
-          id: commentRow.id,
-          threadId: commentRow.thread_id,
-          parentId: commentRow.parent_comment_id,
-          body: DELETED_BODY,
-          createdAt: commentRow.created_at,
-          author: maskedAuthor(),
-          isAuthor: false,
-          isOp: false,
-          isDeleted: true,
-          editedAt: null,
         };
       }
       const commenter = commenterProfilesById.get(commentRow.author_id);
@@ -414,33 +636,10 @@ export class CommunityRoomThreadService {
     function buildRoot(
       commentRow: CommentRow,
     ): MobileCommunityRoomThreadComment | null {
-      if (commentRow.deleted_at) {
+      if (commentRow.deleted_at || blockedIds.has(commentRow.author_id)) {
         return {
-          id: commentRow.id,
-          threadId: commentRow.thread_id,
-          parentId: null,
-          body: DELETED_BODY,
-          createdAt: commentRow.deleted_at,
-          author: maskedAuthor(),
-          isAuthor: false,
-          isOp: false,
-          isDeleted: true,
-          editedAt: null,
-          replies: [],
-        };
-      }
-      if (blockedIds.has(commentRow.author_id)) {
-        return {
-          id: commentRow.id,
-          threadId: commentRow.thread_id,
-          parentId: null,
-          body: DELETED_BODY,
-          createdAt: commentRow.created_at,
-          author: maskedAuthor(),
-          isAuthor: false,
-          isOp: false,
-          isDeleted: true,
-          editedAt: null,
+          ...baseDeleted(commentRow),
+          parentId: commentRow.parent_comment_id,
           replies: [],
         };
       }
@@ -449,7 +648,7 @@ export class CommunityRoomThreadService {
       return {
         id: commentRow.id,
         threadId: commentRow.thread_id,
-        parentId: null,
+        parentId: commentRow.parent_comment_id,
         body: commentRow.body,
         createdAt: commentRow.created_at,
         author: {
@@ -486,9 +685,7 @@ export class CommunityRoomThreadService {
           continue;
         }
       }
-
-      // Orphan: parent missing. Bubble up as top-level for graceful degradation.
-      orphanedChildren.push(child);
+      if (bubbleOrphans) orphanedChildren.push(child);
     }
 
     const comments: MobileCommunityRoomThreadComment[] = Array.from(
@@ -498,7 +695,7 @@ export class CommunityRoomThreadService {
     for (const orphan of orphanedChildren) {
       comments.push({
         ...orphan,
-        parentId: null,
+        parentId: orphan.parentId,
         replies: [],
       });
     }
@@ -507,13 +704,10 @@ export class CommunityRoomThreadService {
     comments.sort(
       (a, b) =>
         direction *
-        (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
+          (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) ||
+        direction * a.id.localeCompare(b.id),
     );
-
-    return {
-      thread: shapeThread(row, author, viewerId),
-      comments,
-    };
+    return comments;
   }
 
   static async createComment({

--- a/src/services/communityRoomThreadService.ts
+++ b/src/services/communityRoomThreadService.ts
@@ -1,0 +1,892 @@
+import type {
+  MobileCommunityRoomCommentSort,
+  MobileCommunityRoomThread,
+  MobileCommunityRoomThreadChildComment,
+  MobileCommunityRoomThreadComment,
+  MobileCommunityRoomThreadCommentDraft,
+  MobileCommunityRoomThreadCommentEditDraft,
+  MobileCommunityRoomThreadDetail,
+  MobileCommunityRoomThreadDraft,
+  MobileCommunityRoomThreadEditDraft,
+  MobileCommunityRoomThreadList,
+} from "@kurecal/domain";
+
+import { BlockService } from "@/services/blockService";
+import type { SupabaseClientType } from "@/types";
+
+const THREAD_LIST_DEFAULT_LIMIT = 20;
+const THREAD_LIST_MAX_LIMIT = 50;
+const COMMENT_LIST_LIMIT = 200;
+
+// See communityRoomService.ts — event_room_threads isn't in the generated
+// Database types yet. Remove once `supabase gen types` has been re-run.
+function untypedClient(client: SupabaseClientType): any {
+  return client as any;
+}
+
+export class CommunityRoomThreadNotFoundError extends Error {
+  constructor(threadId: string) {
+    super(`Thread not found: ${threadId}`);
+    this.name = "CommunityRoomThreadNotFoundError";
+  }
+}
+
+/**
+ * Throw a generic-message Error after logging the raw cause server-side.
+ * Used by the thread/comment service so Supabase/Postgres details (column
+ * names, constraint hints, RLS reasons) don't leak to the API response.
+ */
+function fail(operation: string, cause: unknown): never {
+  console.error(`[communityRoomThreadService] ${operation} failed`, cause);
+  throw new Error(operation);
+}
+
+interface ThreadRow {
+  id: string;
+  event_id: string;
+  author_id: string;
+  title: string;
+  body: string;
+  comment_count: number;
+  created_at: string;
+  last_activity_at: string;
+  deleted_at: string | null;
+  edited_at: string | null;
+}
+
+interface AuthorProfileRow {
+  id: string;
+  full_name: string | null;
+  username: string | null;
+  avatar_url: string | null;
+  headline: string | null;
+}
+
+interface CommentRow {
+  id: string;
+  thread_id: string;
+  author_id: string;
+  body: string;
+  created_at: string;
+  parent_comment_id: string | null;
+  deleted_at: string | null;
+  edited_at: string | null;
+}
+
+const THREAD_COLUMNS =
+  "id, event_id, author_id, title, body, comment_count, created_at, last_activity_at, deleted_at, edited_at";
+
+const COMMENT_COLUMNS =
+  "id, thread_id, author_id, body, created_at, parent_comment_id, deleted_at, edited_at";
+
+const DELETED_AUTHOR_ID = "00000000-0000-0000-0000-000000000000";
+const DELETED_BODY = "[deleted]";
+
+function shapeThread(
+  row: ThreadRow,
+  author: AuthorProfileRow,
+  viewerId: string,
+): MobileCommunityRoomThread {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    commentCount: row.comment_count,
+    createdAt: row.created_at,
+    lastActivityAt: row.last_activity_at,
+    author: {
+      id: author.id,
+      fullName: author.full_name,
+      username: author.username ?? "",
+      avatarUrl: author.avatar_url,
+      headline: author.headline,
+    },
+    isAuthor: row.author_id === viewerId,
+    editedAt: row.edited_at,
+  };
+}
+
+function maskedAuthor(): MobileCommunityRoomThreadComment["author"] {
+  return {
+    id: DELETED_AUTHOR_ID,
+    fullName: null,
+    username: "deleted",
+    avatarUrl: null,
+  };
+}
+
+export class CommunityRoomThreadService {
+  static async createThread({
+    eventId,
+    authorId,
+    draft,
+    writeClient,
+  }: {
+    eventId: string;
+    authorId: string;
+    draft: MobileCommunityRoomThreadDraft;
+    writeClient: SupabaseClientType;
+  }): Promise<MobileCommunityRoomThread> {
+    const eventResult = await writeClient
+      .from("events")
+      .select("id, status")
+      .eq("id", eventId)
+      .eq("status", "confirmed")
+      .maybeSingle();
+
+    if (eventResult.error) {
+      throw new Error("Failed to verify event.");
+    }
+    if (!eventResult.data) {
+      throw new Error("Event not found.");
+    }
+
+    const insertResult = (await untypedClient(writeClient)
+      .from("event_room_threads")
+      .insert({
+        event_id: eventId,
+        author_id: authorId,
+        title: draft.title.trim(),
+        body: draft.body.trim(),
+      })
+      .select(THREAD_COLUMNS)
+      .single()) as { data: unknown; error: { message?: string } | null };
+
+    if (insertResult.error || !insertResult.data) {
+      fail("Failed to create thread.", insertResult.error);
+    }
+
+    const row = insertResult.data as ThreadRow;
+
+    const authorResult = await writeClient
+      .from("profiles")
+      .select("id, full_name, avatar_url, username, headline")
+      .eq("id", authorId)
+      .maybeSingle();
+
+    if (authorResult.error || !authorResult.data) {
+      throw new Error("Failed to load thread author profile.");
+    }
+
+    const author = authorResult.data as AuthorProfileRow;
+    if (!author.username) {
+      throw new Error("Author profile is incomplete.");
+    }
+
+    return shapeThread(row, author, authorId);
+  }
+
+  static async listThreads({
+    eventId,
+    viewerId,
+    readClient,
+    cursor,
+    limit = THREAD_LIST_DEFAULT_LIMIT,
+  }: {
+    eventId: string;
+    viewerId: string;
+    readClient: SupabaseClientType;
+    cursor?: string | null;
+    limit?: number;
+  }): Promise<MobileCommunityRoomThreadList> {
+    const cappedLimit = Math.min(Math.max(limit, 1), THREAD_LIST_MAX_LIMIT);
+
+    let query = untypedClient(readClient)
+      .from("event_room_threads")
+      .select(THREAD_COLUMNS)
+      .eq("event_id", eventId)
+      .is("deleted_at", null)
+      .order("last_activity_at", { ascending: false });
+
+    if (cursor) {
+      query = query.lt("last_activity_at", cursor);
+    }
+
+    const result = (await query.limit(cappedLimit + 1)) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (result.error) {
+      fail("Failed to load threads.", result.error);
+    }
+
+    const rows = (result.data ?? []) as ThreadRow[];
+    const hasMore = rows.length > cappedLimit;
+    const page = hasMore ? rows.slice(0, cappedLimit) : rows;
+
+    if (page.length === 0) {
+      return { threads: [], nextCursor: null };
+    }
+
+    const authorIds = Array.from(new Set(page.map((row) => row.author_id)));
+    const authorsResult = await readClient
+      .from("profiles")
+      .select("id, full_name, avatar_url, username, headline")
+      .in("id", authorIds);
+
+    if (authorsResult.error) {
+      throw new Error("Failed to load thread authors.");
+    }
+
+    const authorsById = new Map<string, AuthorProfileRow>(
+      ((authorsResult.data || []) as AuthorProfileRow[]).map((row) => [
+        row.id,
+        row,
+      ]),
+    );
+
+    const threads: MobileCommunityRoomThread[] = [];
+    for (const row of page) {
+      const author = authorsById.get(row.author_id);
+      if (!author || !author.username) continue;
+      threads.push(shapeThread(row, author, viewerId));
+    }
+
+    return {
+      threads,
+      nextCursor: hasMore ? page[page.length - 1].last_activity_at : null,
+    };
+  }
+
+  static async getThreadDetail({
+    eventId,
+    threadId,
+    viewerId,
+    readClient,
+    sort = "oldest",
+  }: {
+    eventId: string;
+    threadId: string;
+    viewerId: string;
+    readClient: SupabaseClientType;
+    sort?: MobileCommunityRoomCommentSort;
+  }): Promise<MobileCommunityRoomThreadDetail> {
+    const threadResult = (await untypedClient(readClient)
+      .from("event_room_threads")
+      .select(THREAD_COLUMNS)
+      .eq("id", threadId)
+      .eq("event_id", eventId)
+      .maybeSingle()) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (threadResult.error) {
+      fail("Failed to load thread.", threadResult.error);
+    }
+    if (!threadResult.data) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+
+    const row = threadResult.data as ThreadRow;
+
+    // Soft-deleted threads behave as if they no longer exist.
+    if (row.deleted_at) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+
+    const [authorResult, commentsResult] = await Promise.all([
+      readClient
+        .from("profiles")
+        .select("id, full_name, avatar_url, username, headline")
+        .eq("id", row.author_id)
+        .maybeSingle(),
+      untypedClient(readClient)
+        .from("event_room_thread_comments")
+        .select(COMMENT_COLUMNS)
+        .eq("thread_id", threadId)
+        .order("created_at", { ascending: true })
+        .limit(COMMENT_LIST_LIMIT),
+    ]);
+
+    if (authorResult.error || !authorResult.data) {
+      throw new Error("Failed to load thread author.");
+    }
+
+    const commentsRaw = commentsResult as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+    if (commentsRaw.error) {
+      fail("Failed to load thread comments.", commentsRaw.error);
+    }
+
+    const author = authorResult.data as AuthorProfileRow;
+    if (!author.username) {
+      throw new Error("Thread author profile is incomplete.");
+    }
+
+    const commentRows = (commentsRaw.data ?? []) as CommentRow[];
+    const commenterIds = Array.from(
+      new Set(commentRows.map((c) => c.author_id)),
+    );
+
+    const commenterProfilesById = new Map<string, AuthorProfileRow>();
+    if (commenterIds.length > 0) {
+      const commenterProfilesResult = await readClient
+        .from("profiles")
+        .select("id, full_name, avatar_url, username, headline")
+        .in("id", commenterIds);
+
+      if (commenterProfilesResult.error) {
+        throw new Error("Failed to load comment authors.");
+      }
+
+      for (const profile of (commenterProfilesResult.data ||
+        []) as AuthorProfileRow[]) {
+        commenterProfilesById.set(profile.id, profile);
+      }
+    }
+
+    const threadAuthorId = row.author_id;
+    const rootIds = new Set(
+      commentRows.filter((c) => c.parent_comment_id === null).map((c) => c.id),
+    );
+
+    // Hide comments authored by users the viewer has blocked. We render the
+    // same tombstone we use for soft-deletes so tree structure is preserved
+    // (e.g. replies under a blocked author's parent stay visible) without
+    // leaking the blocked author's content or identity.
+    const blockedIds =
+      commenterIds.length > 0
+        ? await BlockService.getBlockedUserIdsForViewer(
+            viewerId,
+            commenterIds,
+            readClient,
+          )
+        : new Set<string>();
+
+    function buildChild(
+      commentRow: CommentRow,
+    ): MobileCommunityRoomThreadChildComment | null {
+      if (commentRow.deleted_at) {
+        return {
+          id: commentRow.id,
+          threadId: commentRow.thread_id,
+          parentId: commentRow.parent_comment_id,
+          body: DELETED_BODY,
+          // Use the deletion timestamp so the original posting time isn't
+          // leaked to anyone who can request the thread after deletion.
+          createdAt: commentRow.deleted_at,
+          author: maskedAuthor(),
+          isAuthor: false,
+          isOp: false,
+          isDeleted: true,
+          editedAt: null,
+        };
+      }
+      if (blockedIds.has(commentRow.author_id)) {
+        return {
+          id: commentRow.id,
+          threadId: commentRow.thread_id,
+          parentId: commentRow.parent_comment_id,
+          body: DELETED_BODY,
+          createdAt: commentRow.created_at,
+          author: maskedAuthor(),
+          isAuthor: false,
+          isOp: false,
+          isDeleted: true,
+          editedAt: null,
+        };
+      }
+      const commenter = commenterProfilesById.get(commentRow.author_id);
+      if (!commenter || !commenter.username) return null;
+      return {
+        id: commentRow.id,
+        threadId: commentRow.thread_id,
+        parentId: commentRow.parent_comment_id,
+        body: commentRow.body,
+        createdAt: commentRow.created_at,
+        author: {
+          id: commenter.id,
+          fullName: commenter.full_name,
+          username: commenter.username,
+          avatarUrl: commenter.avatar_url,
+        },
+        isAuthor: commentRow.author_id === viewerId,
+        isOp: commentRow.author_id === threadAuthorId,
+        isDeleted: false,
+        editedAt: commentRow.edited_at,
+      };
+    }
+
+    function buildRoot(
+      commentRow: CommentRow,
+    ): MobileCommunityRoomThreadComment | null {
+      if (commentRow.deleted_at) {
+        return {
+          id: commentRow.id,
+          threadId: commentRow.thread_id,
+          parentId: null,
+          body: DELETED_BODY,
+          createdAt: commentRow.deleted_at,
+          author: maskedAuthor(),
+          isAuthor: false,
+          isOp: false,
+          isDeleted: true,
+          editedAt: null,
+          replies: [],
+        };
+      }
+      if (blockedIds.has(commentRow.author_id)) {
+        return {
+          id: commentRow.id,
+          threadId: commentRow.thread_id,
+          parentId: null,
+          body: DELETED_BODY,
+          createdAt: commentRow.created_at,
+          author: maskedAuthor(),
+          isAuthor: false,
+          isOp: false,
+          isDeleted: true,
+          editedAt: null,
+          replies: [],
+        };
+      }
+      const commenter = commenterProfilesById.get(commentRow.author_id);
+      if (!commenter || !commenter.username) return null;
+      return {
+        id: commentRow.id,
+        threadId: commentRow.thread_id,
+        parentId: null,
+        body: commentRow.body,
+        createdAt: commentRow.created_at,
+        author: {
+          id: commenter.id,
+          fullName: commenter.full_name,
+          username: commenter.username,
+          avatarUrl: commenter.avatar_url,
+        },
+        isAuthor: commentRow.author_id === viewerId,
+        isOp: commentRow.author_id === threadAuthorId,
+        isDeleted: false,
+        editedAt: commentRow.edited_at,
+        replies: [],
+      };
+    }
+
+    const rootCommentsById = new Map<string, MobileCommunityRoomThreadComment>();
+    const orphanedChildren: MobileCommunityRoomThreadChildComment[] = [];
+
+    for (const commentRow of commentRows) {
+      if (commentRow.parent_comment_id === null) {
+        const root = buildRoot(commentRow);
+        if (root) rootCommentsById.set(commentRow.id, root);
+        continue;
+      }
+
+      const child = buildChild(commentRow);
+      if (!child) continue;
+      const parentId = commentRow.parent_comment_id;
+      if (parentId && rootIds.has(parentId)) {
+        const root = rootCommentsById.get(parentId);
+        if (root) {
+          root.replies.push(child);
+          continue;
+        }
+      }
+
+      // Orphan: parent missing. Bubble up as top-level for graceful degradation.
+      orphanedChildren.push(child);
+    }
+
+    const comments: MobileCommunityRoomThreadComment[] = Array.from(
+      rootCommentsById.values(),
+    );
+
+    for (const orphan of orphanedChildren) {
+      comments.push({
+        ...orphan,
+        parentId: null,
+        replies: [],
+      });
+    }
+
+    const direction = sort === "newest" ? -1 : 1;
+    comments.sort(
+      (a, b) =>
+        direction *
+        (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
+    );
+
+    return {
+      thread: shapeThread(row, author, viewerId),
+      comments,
+    };
+  }
+
+  static async createComment({
+    eventId,
+    threadId,
+    authorId,
+    draft,
+    writeClient,
+  }: {
+    eventId: string;
+    threadId: string;
+    authorId: string;
+    draft: MobileCommunityRoomThreadCommentDraft;
+    writeClient: SupabaseClientType;
+  }): Promise<MobileCommunityRoomThreadComment> {
+    // Verify the thread exists, belongs to the requested event, and is not
+    // soft-deleted, so callers can't post on a guessed thread id or on a
+    // thread whose author has tombstoned it.
+    const threadResult = (await untypedClient(writeClient)
+      .from("event_room_threads")
+      .select("id, event_id, author_id, deleted_at")
+      .eq("id", threadId)
+      .eq("event_id", eventId)
+      .maybeSingle()) as {
+      data: { author_id: string; deleted_at: string | null } | null;
+      error: { message?: string } | null;
+    };
+
+    if (threadResult.error) {
+      fail("Failed to verify thread.", threadResult.error);
+    }
+    if (!threadResult.data || threadResult.data.deleted_at) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+
+    const threadAuthorId = threadResult.data.author_id;
+
+    // Resolve effective parent_comment_id with depth-1 collapse:
+    //   - null / undefined → top-level comment
+    //   - points to a top-level comment in this thread → child
+    //   - points to a depth-1 reply → collapse to that reply's parent
+    //   - points to a non-existent, cross-thread, or soft-deleted comment → 400
+    let parentCommentIdToInsert: string | null = null;
+    if (draft.parentCommentId) {
+      const parentResult = (await untypedClient(writeClient)
+        .from("event_room_thread_comments")
+        .select("id, thread_id, parent_comment_id, deleted_at")
+        .eq("id", draft.parentCommentId)
+        .maybeSingle()) as {
+        data:
+          | {
+              id: string;
+              thread_id: string;
+              parent_comment_id: string | null;
+              deleted_at: string | null;
+            }
+          | null;
+        error: { message?: string } | null;
+      };
+
+      if (parentResult.error) {
+        fail("Failed to verify parent comment.", parentResult.error);
+      }
+      if (
+        !parentResult.data ||
+        parentResult.data.thread_id !== threadId ||
+        parentResult.data.deleted_at
+      ) {
+        throw new Error("Parent comment not found in this thread.");
+      }
+
+      parentCommentIdToInsert =
+        parentResult.data.parent_comment_id ?? parentResult.data.id;
+    }
+
+    const insertResult = (await untypedClient(writeClient)
+      .from("event_room_thread_comments")
+      .insert({
+        thread_id: threadId,
+        author_id: authorId,
+        body: draft.body.trim(),
+        parent_comment_id: parentCommentIdToInsert,
+      })
+      .select(COMMENT_COLUMNS)
+      .single()) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (insertResult.error || !insertResult.data) {
+      fail("Failed to post comment.", insertResult.error);
+    }
+
+    const row = insertResult.data as CommentRow;
+
+    const authorResult = await writeClient
+      .from("profiles")
+      .select("id, full_name, avatar_url, username, headline")
+      .eq("id", authorId)
+      .maybeSingle();
+
+    if (authorResult.error || !authorResult.data) {
+      throw new Error("Failed to load comment author profile.");
+    }
+
+    const author = authorResult.data as AuthorProfileRow;
+    if (!author.username) {
+      throw new Error("Author profile is incomplete.");
+    }
+
+    return {
+      id: row.id,
+      threadId: row.thread_id,
+      parentId: row.parent_comment_id,
+      body: row.body,
+      createdAt: row.created_at,
+      author: {
+        id: author.id,
+        fullName: author.full_name,
+        username: author.username,
+        avatarUrl: author.avatar_url,
+      },
+      isAuthor: true,
+      isDeleted: false,
+      editedAt: row.edited_at,
+      isOp: authorId === threadAuthorId,
+      replies: [],
+    };
+  }
+
+  static async updateThread({
+    eventId,
+    threadId,
+    authorId,
+    draft,
+    writeClient,
+  }: {
+    eventId: string;
+    threadId: string;
+    authorId: string;
+    draft: MobileCommunityRoomThreadEditDraft;
+    writeClient: SupabaseClientType;
+  }): Promise<MobileCommunityRoomThread> {
+    const updateResult = (await untypedClient(writeClient)
+      .from("event_room_threads")
+      .update({
+        title: draft.title.trim(),
+        body: draft.body.trim(),
+        edited_at: new Date().toISOString(),
+      })
+      .eq("id", threadId)
+      .eq("event_id", eventId)
+      .eq("author_id", authorId)
+      .is("deleted_at", null)
+      .select(THREAD_COLUMNS)
+      .maybeSingle()) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (updateResult.error) {
+      fail("Failed to update thread.", updateResult.error);
+    }
+    if (!updateResult.data) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+
+    const row = updateResult.data as ThreadRow;
+
+    const authorResult = await writeClient
+      .from("profiles")
+      .select("id, full_name, avatar_url, username, headline")
+      .eq("id", row.author_id)
+      .maybeSingle();
+
+    if (authorResult.error || !authorResult.data) {
+      throw new Error("Failed to load thread author profile.");
+    }
+
+    const author = authorResult.data as AuthorProfileRow;
+    if (!author.username) {
+      throw new Error("Author profile is incomplete.");
+    }
+
+    return shapeThread(row, author, authorId);
+  }
+
+  static async deleteThread({
+    eventId,
+    threadId,
+    authorId,
+    writeClient,
+  }: {
+    eventId: string;
+    threadId: string;
+    authorId: string;
+    writeClient: SupabaseClientType;
+  }): Promise<void> {
+    const result = (await untypedClient(writeClient)
+      .from("event_room_threads")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", threadId)
+      .eq("event_id", eventId)
+      .eq("author_id", authorId)
+      .is("deleted_at", null)
+      .select("id")
+      .maybeSingle()) as {
+      data: { id: string } | null;
+      error: { message?: string } | null;
+    };
+
+    if (result.error) {
+      fail("Failed to delete thread.", result.error);
+    }
+    if (!result.data) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+  }
+
+  static async updateComment({
+    eventId,
+    threadId,
+    commentId,
+    authorId,
+    draft,
+    writeClient,
+  }: {
+    eventId: string;
+    threadId: string;
+    commentId: string;
+    authorId: string;
+    draft: MobileCommunityRoomThreadCommentEditDraft;
+    writeClient: SupabaseClientType;
+  }): Promise<MobileCommunityRoomThreadComment> {
+    // Confirm the parent thread exists, belongs to the event, and is live.
+    const threadResult = (await untypedClient(writeClient)
+      .from("event_room_threads")
+      .select("id, author_id, deleted_at")
+      .eq("id", threadId)
+      .eq("event_id", eventId)
+      .maybeSingle()) as {
+      data: { author_id: string; deleted_at: string | null } | null;
+      error: { message?: string } | null;
+    };
+
+    if (threadResult.error) {
+      fail("Failed to verify thread.", threadResult.error);
+    }
+    if (!threadResult.data || threadResult.data.deleted_at) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+
+    const threadAuthorId = threadResult.data.author_id;
+
+    const updateResult = (await untypedClient(writeClient)
+      .from("event_room_thread_comments")
+      .update({
+        body: draft.body.trim(),
+        edited_at: new Date().toISOString(),
+      })
+      .eq("id", commentId)
+      .eq("thread_id", threadId)
+      .eq("author_id", authorId)
+      .is("deleted_at", null)
+      .select(COMMENT_COLUMNS)
+      .maybeSingle()) as {
+      data: unknown;
+      error: { message?: string } | null;
+    };
+
+    if (updateResult.error) {
+      fail("Failed to update comment.", updateResult.error);
+    }
+    if (!updateResult.data) {
+      throw new Error("Comment not found or not editable.");
+    }
+
+    const row = updateResult.data as CommentRow;
+
+    const authorResult = await writeClient
+      .from("profiles")
+      .select("id, full_name, avatar_url, username, headline")
+      .eq("id", row.author_id)
+      .maybeSingle();
+
+    if (authorResult.error || !authorResult.data) {
+      throw new Error("Failed to load comment author profile.");
+    }
+
+    const author = authorResult.data as AuthorProfileRow;
+    if (!author.username) {
+      throw new Error("Author profile is incomplete.");
+    }
+
+    return {
+      id: row.id,
+      threadId: row.thread_id,
+      parentId: row.parent_comment_id,
+      body: row.body,
+      createdAt: row.created_at,
+      author: {
+        id: author.id,
+        fullName: author.full_name,
+        username: author.username,
+        avatarUrl: author.avatar_url,
+      },
+      isAuthor: row.author_id === authorId,
+      isOp: row.author_id === threadAuthorId,
+      isDeleted: false,
+      editedAt: row.edited_at,
+      replies: [],
+    };
+  }
+
+  static async deleteComment({
+    eventId,
+    threadId,
+    commentId,
+    authorId,
+    writeClient,
+  }: {
+    eventId: string;
+    threadId: string;
+    commentId: string;
+    authorId: string;
+    writeClient: SupabaseClientType;
+  }): Promise<void> {
+    // Verify the thread exists and isn't already tombstoned so the RPC
+    // doesn't decrement a thread the caller can't actually mutate.
+    const threadResult = (await untypedClient(writeClient)
+      .from("event_room_threads")
+      .select("id, deleted_at")
+      .eq("id", threadId)
+      .eq("event_id", eventId)
+      .maybeSingle()) as {
+      data: { id: string; deleted_at: string | null } | null;
+      error: { message?: string } | null;
+    };
+
+    if (threadResult.error) {
+      fail("Failed to verify thread.", threadResult.error);
+    }
+    if (!threadResult.data || threadResult.data.deleted_at) {
+      throw new CommunityRoomThreadNotFoundError(threadId);
+    }
+
+    const deleteResult = (await untypedClient(writeClient)
+      .from("event_room_thread_comments")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", commentId)
+      .eq("thread_id", threadId)
+      .eq("author_id", authorId)
+      .is("deleted_at", null)
+      .select("id")
+      .maybeSingle()) as {
+      data: { id: string } | null;
+      error: { message?: string } | null;
+    };
+
+    if (deleteResult.error) {
+      fail("Failed to delete comment.", deleteResult.error);
+    }
+    if (!deleteResult.data) {
+      throw new Error("Comment not found or not deletable.");
+    }
+
+    // The activity trigger only fires on INSERT/DELETE rows, so soft-delete
+    // requires us to decrement the parent thread's comment_count separately.
+    // Use the atomic RPC so concurrent soft-deletes don't race on a stale
+    // read-then-write of the counter. The RPC clamps at zero internally.
+    await untypedClient(writeClient).rpc(
+      "event_room_thread_decrement_comment_count",
+      { p_thread_id: threadId },
+    );
+  }
+}

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -116,6 +116,19 @@ export class ProfileService {
         supabaseClient: SupabaseClientType
     ): Promise<AppProfile> {
         try {
+            // Reject avatar URLs that aren't https. React Native's <Image> will
+            // happily render `data:`, `file:`, or even `javascript:` schemes on
+            // some platforms, so the safest gate is at the write boundary.
+            // `https://` is the only scheme we ever store from the upload path
+            // (uploadAvatar uses `urlData.publicUrl` which is always https).
+            if (
+                Object.prototype.hasOwnProperty.call(updates, 'avatarUrl') &&
+                updates.avatarUrl != null &&
+                !/^https:\/\//i.test(updates.avatarUrl)
+            ) {
+                throw new Error('Avatar URL must use https.');
+            }
+
             const supabaseUpdates = profileTransformer.toSupabase(updates);
             const { data, error } = await supabaseClient
                 .from('profiles')

--- a/supabase/migrations/20260515_event_room_threads.sql
+++ b/supabase/migrations/20260515_event_room_threads.sql
@@ -1,0 +1,126 @@
+-- Event room threads: lightweight discussion seeded around an event.
+-- A thread belongs to an event and an author; comments belong to a thread.
+
+create table if not exists public.event_room_threads (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references public.events(id) on delete cascade,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  title text not null check (char_length(title) between 1 and 200),
+  body text not null check (char_length(body) <= 5000),
+  comment_count integer not null default 0,
+  last_activity_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists event_room_threads_event_recent_idx
+  on public.event_room_threads (event_id, last_activity_at desc);
+
+create index if not exists event_room_threads_author_idx
+  on public.event_room_threads (author_id);
+
+create table if not exists public.event_room_thread_comments (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.event_room_threads(id) on delete cascade,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  body text not null check (char_length(body) between 1 and 2000),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists event_room_thread_comments_thread_idx
+  on public.event_room_thread_comments (thread_id, created_at desc);
+
+create index if not exists event_room_thread_comments_author_idx
+  on public.event_room_thread_comments (author_id);
+
+-- Bump thread.comment_count + last_activity_at when a comment is added.
+create or replace function public.bump_event_room_thread_activity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    update public.event_room_threads
+    set comment_count = comment_count + 1,
+        last_activity_at = greatest(last_activity_at, new.created_at),
+        updated_at = now()
+    where id = new.thread_id;
+    return new;
+  elsif tg_op = 'DELETE' then
+    update public.event_room_threads
+    set comment_count = greatest(comment_count - 1, 0),
+        updated_at = now()
+    where id = old.thread_id;
+    return old;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_event_room_thread_comments_activity
+  on public.event_room_thread_comments;
+
+create trigger trg_event_room_thread_comments_activity
+  after insert or delete on public.event_room_thread_comments
+  for each row execute function public.bump_event_room_thread_activity();
+
+-- Row level security
+alter table public.event_room_threads enable row level security;
+
+drop policy if exists event_room_threads_select on public.event_room_threads;
+create policy event_room_threads_select
+  on public.event_room_threads
+  for select
+  using (auth.uid() is not null);
+
+drop policy if exists event_room_threads_insert on public.event_room_threads;
+create policy event_room_threads_insert
+  on public.event_room_threads
+  for insert
+  with check (author_id = auth.uid());
+
+drop policy if exists event_room_threads_update on public.event_room_threads;
+create policy event_room_threads_update
+  on public.event_room_threads
+  for update
+  using (author_id = auth.uid())
+  with check (author_id = auth.uid());
+
+drop policy if exists event_room_threads_delete on public.event_room_threads;
+create policy event_room_threads_delete
+  on public.event_room_threads
+  for delete
+  using (author_id = auth.uid());
+
+alter table public.event_room_thread_comments enable row level security;
+
+drop policy if exists event_room_thread_comments_select
+  on public.event_room_thread_comments;
+create policy event_room_thread_comments_select
+  on public.event_room_thread_comments
+  for select
+  using (auth.uid() is not null);
+
+drop policy if exists event_room_thread_comments_insert
+  on public.event_room_thread_comments;
+create policy event_room_thread_comments_insert
+  on public.event_room_thread_comments
+  for insert
+  with check (author_id = auth.uid());
+
+drop policy if exists event_room_thread_comments_update
+  on public.event_room_thread_comments;
+create policy event_room_thread_comments_update
+  on public.event_room_thread_comments
+  for update
+  using (author_id = auth.uid())
+  with check (author_id = auth.uid());
+
+drop policy if exists event_room_thread_comments_delete
+  on public.event_room_thread_comments;
+create policy event_room_thread_comments_delete
+  on public.event_room_thread_comments
+  for delete
+  using (author_id = auth.uid());

--- a/supabase/migrations/20260516_event_room_soft_delete_and_edits.sql
+++ b/supabase/migrations/20260516_event_room_soft_delete_and_edits.sql
@@ -1,0 +1,17 @@
+-- Soft-delete + edit-tracking for event room threads and comments.
+-- Soft delete keeps row structure intact so child replies under a
+-- "deleted" parent still render. The service masks the body and author
+-- on read.
+
+alter table public.event_room_threads
+  add column if not exists deleted_at timestamptz null,
+  add column if not exists edited_at  timestamptz null;
+
+alter table public.event_room_thread_comments
+  add column if not exists deleted_at timestamptz null,
+  add column if not exists edited_at  timestamptz null;
+
+-- Skip soft-deleted threads in list/index queries.
+create index if not exists event_room_threads_active_recent_idx
+  on public.event_room_threads (event_id, last_activity_at desc)
+  where deleted_at is null;

--- a/supabase/migrations/20260516_event_room_thread_comments_nested.sql
+++ b/supabase/migrations/20260516_event_room_thread_comments_nested.sql
@@ -1,0 +1,10 @@
+-- Allow one level of comment nesting on event room threads.
+-- The service layer enforces the depth-1 cap by collapsing
+-- "reply-to-a-reply" attempts onto the top-level grandparent.
+
+alter table public.event_room_thread_comments
+  add column if not exists parent_comment_id uuid
+  references public.event_room_thread_comments(id) on delete cascade;
+
+create index if not exists event_room_thread_comments_parent_idx
+  on public.event_room_thread_comments (parent_comment_id);

--- a/supabase/migrations/20260516_widen_community_reports_subject_type.sql
+++ b/supabase/migrations/20260516_widen_community_reports_subject_type.sql
@@ -1,0 +1,15 @@
+-- Widen the community_reports.subject_type check constraint to accept
+-- event-thread content alongside circle posts / comments / profiles.
+
+alter table public.community_reports
+  drop constraint if exists community_reports_subject_type_check;
+
+alter table public.community_reports
+  add constraint community_reports_subject_type_check
+  check (subject_type = ANY (ARRAY[
+    'post'::text,
+    'comment'::text,
+    'profile'::text,
+    'event_thread'::text,
+    'event_thread_comment'::text
+  ]));

--- a/supabase/migrations/20260517002108_enable_event_room_thread_comment_realtime.sql
+++ b/supabase/migrations/20260517002108_enable_event_room_thread_comment_realtime.sql
@@ -1,0 +1,15 @@
+alter table public.event_room_thread_comments replica identity full;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'event_room_thread_comments'
+  ) then
+    alter publication supabase_realtime
+      add table public.event_room_thread_comments;
+  end if;
+end $$;

--- a/supabase/migrations/20260517_event_room_thread_comment_count_atomic.sql
+++ b/supabase/migrations/20260517_event_room_thread_comment_count_atomic.sql
@@ -1,0 +1,21 @@
+-- Atomic decrement of event_room_threads.comment_count for soft-delete.
+-- The existing INSERT/DELETE trigger doesn't fire on UPDATE-based soft-deletes,
+-- so the service previously did a read-then-write that could race under
+-- concurrent deletes. This RPC evaluates `greatest(0, comment_count - 1)`
+-- inside a single UPDATE so Postgres row-locking handles concurrency.
+
+create or replace function public.event_room_thread_decrement_comment_count(
+  p_thread_id uuid
+)
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  update public.event_room_threads
+  set comment_count = greatest(0, comment_count - 1),
+      updated_at = now()
+  where id = p_thread_id;
+$$;
+
+grant execute on function public.event_room_thread_decrement_comment_count(uuid) to authenticated, service_role;


### PR DESCRIPTION
…y hardening

Adds full thread/comment infrastructure under event rooms, lifts threads out of the room bottom sheet into dedicated routes, and ships the ownership/moderation primitives needed to reach Reddit-grade feature parity (sans voting). Closes a full security audit on the resulting surface.

Backend
- New tables: event_room_threads + event_room_thread_comments with comment-count trigger, RLS by author_id, 1-level nesting (parent_comment_id), soft-delete (deleted_at) + edit (edited_at) columns, and an atomic decrement RPC for soft-delete counter races.
- Widens community_reports.subject_type to accept event_thread + event_thread_comment so the existing report flow covers thread content.
- New CommunityRoomService.getRoomDetail() returns event + viewer state + visible attendees + signals + thread count, applying BlockService and viewer visibility rules.
- New CommunityRoomThreadService with createThread, listThreads (cursor on last_activity_at, soft-delete filter), getThreadDetail (tree-build with depth-1 cap, soft-delete + blocked-author masking, Newest/Oldest sort), createComment (depth-1 collapse for reply-to-a-reply, parent + thread soft-delete checks), updateThread, deleteThread, updateComment, deleteComment.

Routes (all under /api/mobile/community/rooms/[eventId])
- GET / PATCH / DELETE /threads/[threadId] (with ?sort= query)
- GET / POST /threads
- POST /threads/[threadId]/comments
- PATCH / DELETE /threads/[threadId]/comments/[commentId]
- All mutation routes gated by sliding-window rate limit (429 + Retry-After), UUID-validated URL params, and generic error messages that don't leak Supabase/Postgres internals.
- /api/community/reports gets the same rate-limit gate.

Mobile (apps/mobile)
- Sheet refactor: drops the inline thread composer, replaces with a navigation tile that routes to /event/[id]/threads.
- New routes: threads index (paginated, Start-a-thread CTA), new thread composer, thread detail (Reddit-style byline + body + comments tree with 1-level indent + thread bar, OP badge, optimistic posting, empty-state hint, sort toggle, permalink scroll/highlight).
- New components: CommunityThreadActionMenu (bottom sheet), CommunityThreadReportSheet (reason picker).
- MobilePage gains an optional scrollRef prop so permalinks can scroll.
- Avatar https whitelist applied across thread/sheet surfaces; profile service rejects non-https avatar_url on write.
- Composer disables Post while a create is in flight; same guard on edit save handlers. All error toasts now show generic copy and log the raw cause for engineers.

Migrations applied to remote DB:
- 20260515_event_room_threads.sql
- 20260516_event_room_thread_comments_nested.sql
- 20260516_event_room_soft_delete_and_edits.sql
- 20260516_widen_community_reports_subject_type.sql
- 20260517_event_room_thread_comment_count_atomic.sql