### PR TITLE
feat(mobile): replace fabricated profile event notes with real connec…

### DIFF
--- a/apps/mobile/app/profile/[username].tsx
+++ b/apps/mobile/app/profile/[username].tsx
@@ -206,17 +206,13 @@ function formatEventMeta(event: ProfileEvent): string {
   return parts.join(' · ');
 }
 
-function getJourneyNote(event: ProfileEvent, index: number): string | null {
-  if (event.activityType === 'attending' || event.activityType === 'speaking') {
-    return index === 0 ? 'Open to introductions' : 'Planning to meet people here';
+function getJourneyNote(event: ProfileEvent): string | null {
+  // Only show a sub-note when there's a real backing signal. Today that's
+  // the owner-only `connectionsMadeCount`, sourced from
+  // user_networking_contacts via get_event_connection_counts_for_user.
+  if (event.connectionsMadeCount && event.connectionsMadeCount > 0) {
+    return `Made ${pluralize(event.connectionsMadeCount, 'connection')}`;
   }
-
-  if (event.mutualAttendeeCount && event.mutualAttendeeCount > 0) {
-    return `Met ${pluralize(event.mutualAttendeeCount, 'person', 'people')} here`;
-  }
-
-  if (/norfolk/i.test(event.title)) return 'Saved 2 speakers';
-  if (/kubevirt|virtual/i.test(event.title)) return 'Made 5 new connections';
   return null;
 }
 
@@ -944,7 +940,7 @@ function JourneyTimeline({
         const isUpcoming =
           event.activityType === 'attending' || event.activityType === 'speaking';
         const meta = formatEventMeta(event);
-        const note = getJourneyNote(event, index);
+        const note = getJourneyNote(event);
         return (
           <Pressable
             key={event.id}

--- a/packages/domain/src/community.ts
+++ b/packages/domain/src/community.ts
@@ -408,6 +408,7 @@ export const mobilePublicProfileEventSchema = z.object({
   activityType: mobilePublicProfileEventActivityTypeSchema,
   role: z.string().nullable().optional(),
   mutualAttendeeCount: z.number().int().nonnegative().nullable().optional(),
+  connectionsMadeCount: z.number().int().nonnegative().nullable().optional(),
 });
 
 export const mobilePublicProfileCareerSchema = z.object({

--- a/src/app/api/mobile/communitySerializers.ts
+++ b/src/app/api/mobile/communitySerializers.ts
@@ -496,6 +496,7 @@ export function toMobilePublicProfile(
       activityType: event.activityType,
       role: event.role,
       mutualAttendeeCount: event.mutualAttendeeCount,
+      connectionsMadeCount: event.connectionsMadeCount,
     })),
     eventCounts: profile.eventCounts,
     careerProfile: profile.careerProfile

--- a/src/app/api/mobile/profiles/[username]/route.test.ts
+++ b/src/app/api/mobile/profiles/[username]/route.test.ts
@@ -88,6 +88,7 @@ describe('GET /api/mobile/profiles/[username]', () => {
           activityType: 'attending',
           role: null,
           mutualAttendeeCount: null,
+          connectionsMadeCount: null,
         },
       ],
       careerProfile: {

--- a/src/services/publicProfileService.ts
+++ b/src/services/publicProfileService.ts
@@ -63,6 +63,7 @@ export interface PublicProfileEvent {
   activityType: PublicProfileEventActivityType;
   role: string | null;
   mutualAttendeeCount: number | null;
+  connectionsMadeCount: number | null;
 }
 
 export interface PublicCareerProfile {
@@ -777,8 +778,35 @@ export class PublicProfileService {
         activityType,
         role: link?.role ?? null,
         mutualAttendeeCount: null,
+        connectionsMadeCount: null,
       };
     });
+
+    if (isViewerOwner && events.length > 0) {
+      const eventIds = events.map((event) => event.id);
+      // Cast: RPC is added in 20260523000000_event_connection_counts.sql.
+      const { data: countRows, error: countError } = await (readClient.rpc as unknown as (
+        fn: string,
+        args: Record<string, unknown>
+      ) => Promise<{ data: Array<{ event_id: string; connection_count: number }> | null; error: unknown }>)(
+        'get_event_connection_counts_for_user',
+        {
+          p_user_id: userId,
+          p_event_ids: eventIds,
+        }
+      );
+
+      if (!countError && Array.isArray(countRows)) {
+        const byId = new Map<string, number>();
+        for (const row of countRows as Array<{ event_id: string; connection_count: number }>) {
+          byId.set(row.event_id, row.connection_count);
+        }
+        for (const event of events) {
+          const c = byId.get(event.id);
+          event.connectionsMadeCount = c && c > 0 ? c : null;
+        }
+      }
+    }
 
     if (viewerId && !isViewerOwner && events.length > 0) {
       const eventIds = events.map((event) => event.id);

--- a/supabase/migrations/20260523000000_event_connection_counts.sql
+++ b/supabase/migrations/20260523000000_event_connection_counts.sql
@@ -1,0 +1,26 @@
+-- Per-event count of confirmed networking contacts the user has logged.
+-- Owner-only signal: surfaced on the profile owner's own view as
+-- "Made N connections" under each event in the Recent journey timeline.
+-- Mirrors the structure of get_mutual_attendees_for_events from
+-- 20260521000000_event_activity_model.sql.
+create or replace function public.get_event_connection_counts_for_user(
+  p_user_id uuid,
+  p_event_ids uuid[]
+)
+returns table (event_id uuid, connection_count integer)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    unc.source_event_id as event_id,
+    count(*)::int as connection_count
+  from public.user_networking_contacts unc
+  where unc.viewer_user_id = p_user_id
+    and unc.source_event_id = any(p_event_ids)
+    and unc.confirmed_connected_at is not null
+  group by unc.source_event_id;
+$$;
+
+grant execute on function public.get_event_connection_counts_for_user(uuid, uuid[]) to authenticated;


### PR DESCRIPTION
…tion counts

The Recent journey timeline on the public profile was emitting hardcoded sub-notes per row — 'Open to introductions', 'Planning to meet people here', 'Saved 2 speakers', 'Made 5 new connections' (the last two regex-matched to specific event title keywords). 'Met N people here' also misrepresented mutualAttendeeCount as "people you met" when it actually counts viewer↔target mutual follows who attended.

Replace all of it with one real signal: the count of confirmed networking contacts the profile owner logged with source_event_id = <event>.

- New RPC: get_event_connection_counts_for_user(uuid, uuid[]) returns per-event counts from user_networking_contacts. Owner-private — only called when isViewerOwner=true.
- PublicProfileEvent gains connectionsMadeCount; schema and serializer pass it through.
- JourneyTimeline renders 'Made N connection(s)' under a row only when there's real backing data; everything else dropped.