### PR TITLE
[codex] Fix Google Calendar OAuth and compact mobile integration UI

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -21,6 +21,34 @@ Set these for paid subscriptions:
 - `EXPO_PUBLIC_REVENUECAT_PRO_MONTHLY_PRODUCT_ID`
 - `EXPO_PUBLIC_REVENUECAT_PRO_ANNUAL_PRODUCT_ID`
 
+## Google Calendar OAuth
+
+Web and mobile calendar sync use one server-owned Google OAuth web client. Configure
+the API deployment with:
+
+- `GOOGLE_OAUTH_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET`
+
+Do not configure a separate `NEXT_PUBLIC_GOOGLE_CLIENT_ID` for calendar sync. Add
+both callback paths to the same Google Cloud OAuth client's authorized redirect
+URIs. For local development:
+
+```text
+http://localhost:3000/api/calendar/google/callback
+http://localhost:3000/api/mobile/calendar/google/callback
+```
+
+For production, using the API URL below:
+
+```text
+https://www.kure-cal.com/api/calendar/google/callback
+https://www.kure-cal.com/api/mobile/calendar/google/callback
+```
+
+The native return URLs, `kurecal-dev://calendar/google/callback` and
+`kurecal://calendar/google/callback`, are handled after the server callback and
+are not Google Cloud authorized redirect URIs.
+
 ## Production setup
 
 1. Log in to Expo with `npx eas-cli login`.

--- a/apps/mobile/app/settings/calendar.tsx
+++ b/apps/mobile/app/settings/calendar.tsx
@@ -1,242 +1,451 @@
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Platform, StyleSheet, Text, View } from "react-native";
 import { router } from "expo-router";
+import { SymbolView } from "expo-symbols";
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  StyleSheet,
+  Text,
+    View,
+} from "react-native";
+import Svg, { Path } from "react-native-svg";
 
 import type {
-  MobileCalendarConnectionStatus,
-  NormalizedSubscription,
+    MobileCalendarConnectionStatus,
+    NormalizedSubscription,
 } from "@kurecal/domain";
 
 import {
   SettingsButton,
   SettingsDetailScaffold,
-  SettingsDivider,
-  SettingsFieldLabel,
   SettingsGroup,
-  SettingsRow,
 } from "../../src/components/settings/mobile-settings-ui";
-import { getDeviceCalendarPermissionStatus } from "../../src/lib/deviceCalendarSync";
 import { startGoogleCalendarOAuth } from "../../src/lib/googleCalendarOAuth";
 import {
-  bulkSyncMobileGoogleCalendar,
-  disconnectMobileGoogleCalendar,
-  loadMobileGoogleCalendarStatus,
-  loadMobileSubscriptionStatus,
+    bulkSyncMobileGoogleCalendar,
+    disconnectMobileGoogleCalendar,
+    loadMobileGoogleCalendarStatus,
+    loadMobileSubscriptionStatus,
 } from "../../src/lib/mobileApi";
 import { hasPaidAccess } from "../../src/lib/settingsPresentation";
 import { useAppTheme } from "../../src/providers/ThemeProvider";
 
+function GoogleMark({ size = 22 }: { size?: number }) {
+    return (
+        <Svg height={size} viewBox="0 0 24 24" width={size}>
+            <Path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                fill="#4285F4"
+            />
+            <Path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+            />
+            <Path
+                d="M5.84 14.09A6.6 6.6 0 0 1 5.49 12c0-.73.13-1.43.35-2.09V7.07H2.18A10.98 10.98 0 0 0 1 12c0 1.78.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+            />
+            <Path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+            />
+        </Svg>
+    );
+}
+
 export default function SettingsCalendarRoute() {
-  const { tokens } = useAppTheme();
+    const { tokens } = useAppTheme();
   const [subscription, setSubscription] =
     useState<NormalizedSubscription | null>(null);
   const [googleCalendarStatus, setGoogleCalendarStatus] =
     useState<MobileCalendarConnectionStatus | null>(null);
-  const [appleCalendarPermission, setAppleCalendarPermission] =
-    useState("unknown");
   const [loading, setLoading] = useState(false);
-  const platformSettingsLabel =
-    Platform.OS === "ios" ? "iOS Settings" : "your device settings";
+  const [syncingGoogleCalendar, setSyncingGoogleCalendar] = useState(false);
 
   const refreshCalendarIntegrations = useCallback(async () => {
-    const [nextSubscription, nextGoogleStatus, nextApplePermission] =
-      await Promise.all([
-        loadMobileSubscriptionStatus().catch(() => null),
-        loadMobileGoogleCalendarStatus().catch(() => null),
-        getDeviceCalendarPermissionStatus().catch(() => "unknown"),
-      ]);
+    const [nextSubscription, nextGoogleStatus] = await Promise.all([
+      loadMobileSubscriptionStatus().catch(() => null),
+      loadMobileGoogleCalendarStatus().catch(() => null),
+    ]);
 
     setSubscription(nextSubscription);
     setGoogleCalendarStatus(nextGoogleStatus);
-    setAppleCalendarPermission(nextApplePermission);
   }, []);
 
-  useEffect(() => {
-    void refreshCalendarIntegrations();
-  }, [refreshCalendarIntegrations]);
+    useEffect(() => {
+        void refreshCalendarIntegrations();
+    }, [refreshCalendarIntegrations]);
 
-  async function handleConnectGoogleCalendar() {
-    if (loading) {
-      return;
+    async function handleConnectGoogleCalendar() {
+        if (loading) {
+            return;
+        }
+
+        if (!hasPaidAccess(subscription)) {
+            router.push("../paywall" as never);
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            const connected = await startGoogleCalendarOAuth();
+            if (!connected) {
+                Alert.alert(
+                    "Google Calendar authorization cancelled",
+                    "No changes were made to your calendar integration.",
+                );
+                return;
+            }
+
+            await bulkSyncMobileGoogleCalendar().catch((syncError) => {
+                console.warn("Initial Google Calendar bulk sync failed", syncError);
+            });
+            await refreshCalendarIntegrations();
+            Alert.alert(
+                "Google Calendar connected",
+                "Saved and attending events can now sync to Google Calendar.",
+            );
+        } catch (nextError) {
+            Alert.alert(
+                "Google Calendar connection failed",
+                nextError instanceof Error ? nextError.message : "Please try again.",
+            );
+        } finally {
+            setLoading(false);
+        }
     }
 
-    if (!hasPaidAccess(subscription)) {
-      router.push("../paywall" as never);
-      return;
+    async function handleDisconnectGoogleCalendar() {
+        if (loading) {
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            const nextStatus = await disconnectMobileGoogleCalendar();
+            setGoogleCalendarStatus(nextStatus);
+            Alert.alert(
+                "Google Calendar disconnected",
+                "New event changes will no longer sync to Google Calendar.",
+            );
+        } catch (nextError) {
+            Alert.alert(
+                "Disconnect failed",
+                nextError instanceof Error ? nextError.message : "Please try again.",
+            );
+        } finally {
+            setLoading(false);
+        }
     }
 
-    setLoading(true);
+    async function handleSyncGoogleCalendar() {
+        if (loading || syncingGoogleCalendar) {
+            return;
+        }
 
-    try {
-      const connected = await startGoogleCalendarOAuth();
-      if (!connected) {
-        Alert.alert(
-          "Google Calendar authorization cancelled",
-          "No changes were made to your calendar integration.",
-        );
-        return;
-      }
+        setSyncingGoogleCalendar(true);
 
-      await bulkSyncMobileGoogleCalendar().catch((syncError) => {
-        console.warn("Initial Google Calendar bulk sync failed", syncError);
-      });
-      await refreshCalendarIntegrations();
-      Alert.alert(
-        "Google Calendar connected",
-        "Saved and attending events can now sync to Google Calendar.",
-      );
-    } catch (nextError) {
-      Alert.alert(
-        "Google Calendar connection failed",
-        nextError instanceof Error ? nextError.message : "Please try again.",
-      );
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleDisconnectGoogleCalendar() {
-    if (loading) {
-      return;
+        try {
+            const result = await bulkSyncMobileGoogleCalendar();
+            await refreshCalendarIntegrations();
+            Alert.alert(
+                "Google Calendar synced",
+                result.total > 0
+                    ? `Synced ${result.synced} of ${result.total} saved and attending events.`
+                    : "Your saved and attending events are up to date.",
+            );
+        } catch (nextError) {
+            Alert.alert(
+                "Calendar sync failed",
+                nextError instanceof Error ? nextError.message : "Please try again.",
+            );
+        } finally {
+            setSyncingGoogleCalendar(false);
+        }
     }
 
-    setLoading(true);
+    function formatGoogleCalendarDescription() {
+        if (!hasPaidAccess(subscription)) {
+            return "Upgrade to sync saved and attending events across devices.";
+        }
 
-    try {
-      const nextStatus = await disconnectMobileGoogleCalendar();
-      setGoogleCalendarStatus(nextStatus);
-      Alert.alert(
-        "Google Calendar disconnected",
-        "New event changes will no longer sync to Google Calendar.",
-      );
-    } catch (nextError) {
-      Alert.alert(
-        "Disconnect failed",
-        nextError instanceof Error ? nextError.message : "Please try again.",
-      );
-    } finally {
-      setLoading(false);
+        if (!googleCalendarStatus) {
+            return "Checking Google Calendar connection.";
+        }
+
+        if (googleCalendarStatus.connected && googleCalendarStatus.isActive) {
+            const syncStatus = googleCalendarStatus.lastSyncStatus
+                ? ` Last sync: ${googleCalendarStatus.lastSyncStatus}.`
+                : "";
+            return `Connected to ${googleCalendarStatus.calendarId ?? "Google Calendar"}.${syncStatus}`;
+        }
+
+        if (googleCalendarStatus.status === "needs_reauth") {
+            return "Reconnect Google Calendar to refresh calendar permissions.";
+        }
+
+        if (googleCalendarStatus.status === "failed") {
+            return (
+                googleCalendarStatus.lastSyncError ?? "Google Calendar sync failed."
+            );
+        }
+
+        return "Connect Google Calendar for cross-device calendar sync.";
     }
-  }
-
-  function formatGoogleCalendarDescription() {
-    if (!hasPaidAccess(subscription)) {
-      return "Upgrade to sync saved and attending events across devices.";
-    }
-
-    if (!googleCalendarStatus) {
-      return "Checking Google Calendar connection.";
-    }
-
-    if (googleCalendarStatus.connected && googleCalendarStatus.isActive) {
-      const syncStatus = googleCalendarStatus.lastSyncStatus
-        ? ` Last sync: ${googleCalendarStatus.lastSyncStatus}.`
-        : "";
-      return `Connected to ${googleCalendarStatus.calendarId ?? "Google Calendar"}.${syncStatus}`;
-    }
-
-    if (googleCalendarStatus.status === "needs_reauth") {
-      return "Reconnect Google Calendar to refresh calendar permissions.";
-    }
-
-    if (googleCalendarStatus.status === "failed") {
-      return (
-        googleCalendarStatus.lastSyncError ?? "Google Calendar sync failed."
-      );
-    }
-
-    return "Connect Google Calendar for cross-device calendar sync.";
-  }
-
-  function formatDeviceCalendarDescription() {
-    if (appleCalendarPermission === "granted") {
-      return "Device Calendar saves are enabled on this device. Default reminder: 15 minutes before start.";
-    }
-
-    if (appleCalendarPermission === "denied") {
-      return `Calendar access is denied. Enable access in ${platformSettingsLabel} to save local events.`;
-    }
-
-    return "Device Calendar saves happen locally on this device when you add an event.";
-  }
 
   const googleConnected = Boolean(
-    googleCalendarStatus?.connected && googleCalendarStatus.isActive,
-  );
+        googleCalendarStatus?.connected && googleCalendarStatus.isActive,
+    );
 
-  return (
-    <SettingsDetailScaffold
-      subtitle="Sync"
-      title="Calendar integrations"
-    >
-      <SettingsGroup style={styles.group}>
-        <SettingsFieldLabel>Google Calendar</SettingsFieldLabel>
-        <Text
-          style={[
-            styles.description,
-            {
-              color: tokens.colors.textSecondary,
-              fontFamily: tokens.typography.sans,
-            },
-          ]}
+    function formatLastSync() {
+        if (!googleCalendarStatus?.lastSyncAt) {
+            return googleCalendarStatus?.lastSyncStatus === "success"
+                ? "Synced successfully"
+                : "Ready to sync";
+        }
+
+        const syncTime = new Date(googleCalendarStatus.lastSyncAt);
+        const elapsedMinutes = Math.max(
+            0,
+            Math.floor((Date.now() - syncTime.getTime()) / 60000),
+        );
+
+        if (elapsedMinutes < 1) {
+            return "Synced just now";
+        }
+
+        if (elapsedMinutes < 60) {
+            return `Synced ${elapsedMinutes}m ago`;
+        }
+
+        return `Synced ${syncTime.toLocaleDateString()}`;
+    }
+
+    return (
+        <SettingsDetailScaffold
+            subtitle="Sync"
+            title="Integrations"
         >
-          {formatGoogleCalendarDescription()}
-        </Text>
-        <SettingsButton
-          disabled={loading}
-          label={
-            loading
-              ? "Working..."
-              : googleConnected
-                ? "Disconnect Google"
-                : hasPaidAccess(subscription)
-                  ? "Connect Google"
-                  : "Upgrade to sync"
-          }
-          onPress={() => {
-            void (googleConnected
-              ? handleDisconnectGoogleCalendar()
-              : handleConnectGoogleCalendar());
-          }}
-          variant={googleConnected ? "secondary" : "primary"}
-        />
-      </SettingsGroup>
+            <SettingsGroup style={styles.googleGroup}>
+                <View style={styles.googleRow}>
+                    <View
+                        style={[
+                            styles.googleMarkFrame,
+                            {
+                                backgroundColor: tokens.colors.surfaceMuted,
+                                borderColor: tokens.colors.borderStrong,
+                            },
+                        ]}
+                    >
+                        <GoogleMark />
+                    </View>
+                    <View style={styles.googleCopy}>
+                        <View style={styles.googleTitleRow}>
+                            <Text
+                                style={[
+                                    styles.googleTitle,
+                                    {
+                                        color: tokens.colors.textPrimary,
+                                        fontFamily: tokens.typography.sans,
+                                    },
+                                ]}
+                            >
+                                Google Calendar
+                            </Text>
+                            {googleConnected ? (
+                                <View
+                                    accessibilityLabel="Connected"
+                                    style={[
+                                        styles.connectedDot,
+                                        { backgroundColor: tokens.colors.success },
+                                    ]}
+                                />
+                            ) : null}
+                        </View>
+                        <Text
+                            numberOfLines={1}
+                            selectable
+                            style={[
+                                styles.googleSubtitle,
+                                {
+                                    color: tokens.colors.textTertiary,
+                                    fontFamily: tokens.typography.sans,
+                                },
+                            ]}
+                        >
+                            {googleConnected
+                                ? googleCalendarStatus?.calendarId ?? "Connected"
+                                : formatGoogleCalendarDescription()}
+                        </Text>
+                    </View>
 
-      <SettingsGroup>
-        <SettingsRow
-          icon="calendar"
-          rightLabel={
-            appleCalendarPermission === "granted"
-              ? "Enabled"
-              : appleCalendarPermission === "denied"
-                ? "Denied"
-                : "Local"
-          }
-          showChevron={false}
-          subtitle={formatDeviceCalendarDescription()}
-          title="Device Calendar"
-        />
-        <SettingsDivider />
-        <SettingsRow
-          icon="arrow.clockwise"
-          onPress={() => {
-            void refreshCalendarIntegrations();
-          }}
-          title="Refresh status"
-        />
+                    {googleConnected ? (
+                        <View style={styles.googleActions}>
+                            <Pressable
+                                accessibilityLabel="Sync Google Calendar now"
+                                accessibilityHint={formatLastSync()}
+                                accessibilityRole="button"
+                                disabled={loading || syncingGoogleCalendar}
+                                onPress={() => {
+                                    void handleSyncGoogleCalendar();
+                                }}
+                                style={({ pressed }) => [
+                                    styles.syncButton,
+                                    {
+                                        backgroundColor: tokens.colors.surfaceMuted,
+                                        borderColor: tokens.colors.borderStrong,
+                                    },
+                                    pressed ? styles.pressed : null,
+                                    loading || syncingGoogleCalendar ? styles.disabled : null,
+                                ]}
+                            >
+                                {syncingGoogleCalendar ? (
+                                    <ActivityIndicator
+                                        color={tokens.colors.textTertiary}
+                                        size="small"
+                                    />
+                                ) : (
+                                    <SymbolView
+                                        name="arrow.clockwise"
+                                        size={17}
+                                        tintColor={tokens.colors.textTertiary}
+                                        type="monochrome"
+                                    />
+                                )}
+                            </Pressable>
+                            <Pressable
+                                accessibilityRole="button"
+                                disabled={loading || syncingGoogleCalendar}
+                                onPress={() => {
+                                    void handleDisconnectGoogleCalendar();
+                                }}
+                                style={({ pressed }) => [
+                                    styles.disconnectButton,
+                                    {
+                                        backgroundColor:
+                                            tokens.mode === "dark"
+                                                ? "rgba(255, 180, 171, 0.12)"
+                                                : "rgba(220, 38, 38, 0.09)",
+                                        borderColor:
+                                            tokens.mode === "dark"
+                                                ? "rgba(255, 180, 171, 0.22)"
+                                                : "rgba(220, 38, 38, 0.18)",
+                                    },
+                                    pressed ? styles.pressed : null,
+                                    loading || syncingGoogleCalendar ? styles.disabled : null,
+                                ]}
+                            >
+                                <Text
+                                    style={[
+                                        styles.disconnectLabel,
+                                        {
+                                            color: tokens.colors.danger,
+                                            fontFamily: tokens.typography.sans,
+                                        },
+                                    ]}
+                                >
+                                    {loading ? "Disconnecting..." : "Disconnect"}
+                                </Text>
+                            </Pressable>
+                        </View>
+                    ) : (
+                        <SettingsButton
+                            disabled={loading}
+                            label={
+                                loading
+                                    ? "Working..."
+                                    : hasPaidAccess(subscription)
+                                        ? "Connect"
+                                        : "Upgrade"
+                            }
+                            onPress={() => {
+                                void handleConnectGoogleCalendar();
+                            }}
+                        />
+          )}
+        </View>
       </SettingsGroup>
     </SettingsDetailScaffold>
   );
 }
 
 const styles = StyleSheet.create({
-  group: {
-    gap: 8,
-    padding: 12,
-  },
-  description: {
-    fontSize: 13,
-    fontWeight: "400",
-    lineHeight: 18,
-  },
+    googleGroup: {
+        padding: 12,
+    },
+    googleRow: {
+        alignItems: "center",
+        flexDirection: "row",
+        gap: 10,
+    },
+    googleMarkFrame: {
+        alignItems: "center",
+        borderRadius: 8,
+        borderWidth: 1,
+        height: 40,
+        justifyContent: "center",
+        width: 40,
+    },
+    googleCopy: {
+        flex: 1,
+        gap: 3,
+        minWidth: 0,
+    },
+    googleTitleRow: {
+        alignItems: "center",
+        flexDirection: "row",
+        gap: 8,
+    },
+    googleTitle: {
+        fontSize: 14,
+        fontWeight: "600",
+        lineHeight: 20,
+    },
+    connectedDot: {
+        borderRadius: 5,
+        height: 8,
+        width: 8,
+    },
+    googleSubtitle: {
+        fontSize: 13,
+        fontWeight: "400",
+        lineHeight: 18,
+    },
+    googleActions: {
+        flexDirection: "row",
+        flexShrink: 0,
+        gap: 6,
+    },
+    syncButton: {
+        alignItems: "center",
+        borderRadius: 7,
+        borderWidth: 1,
+        height: 34,
+        justifyContent: "center",
+        width: 36,
+    },
+    disconnectButton: {
+        alignItems: "center",
+        borderRadius: 7,
+        borderWidth: 1,
+        height: 34,
+        justifyContent: "center",
+        minWidth: 92,
+        paddingHorizontal: 10,
+    },
+    disconnectLabel: {
+        fontSize: 13,
+        fontWeight: "600",
+        lineHeight: 20,
+    },
+    pressed: {
+        opacity: 0.76,
+        transform: [{ scale: 0.992 }],
+    },
+    disabled: {
+        opacity: 0.48,
+    },
 });

--- a/apps/mobile/src/lib/googleCalendarOAuth.test.ts
+++ b/apps/mobile/src/lib/googleCalendarOAuth.test.ts
@@ -92,4 +92,30 @@ describe('Google Calendar OAuth helper', () => {
 
     await expect(startGoogleCalendarOAuth()).rejects.toThrow('Sign in required');
   });
+
+  it('surfaces a backend OAuth callback error instead of reporting cancellation', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=abc',
+              returnUrl: 'kurecal://calendar/google/callback',
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    );
+    mocks.openAuthSessionAsync.mockResolvedValue({
+      type: 'success',
+      url: 'kurecal://calendar/google/callback?error=token_exchange_failed',
+    });
+
+    await expect(startGoogleCalendarOAuth()).rejects.toThrow(
+      'Google Calendar authorization could not be completed. Please connect again.'
+    );
+  });
 });

--- a/apps/mobile/src/lib/googleCalendarOAuth.ts
+++ b/apps/mobile/src/lib/googleCalendarOAuth.ts
@@ -6,6 +6,19 @@ import { supabase } from './supabase';
 
 const MOBILE_CALENDAR_OAUTH_RETURN_KEY = 'mobile_calendar_oauth_return_url';
 
+function getOAuthCallbackErrorMessage(errorCode: string): string {
+  switch (errorCode) {
+    case 'invalid_request':
+      return 'Google Calendar authorization expired. Please connect again.';
+    case 'missing_tokens':
+      return 'Google did not provide the required calendar permissions. Please connect again.';
+    case 'token_exchange_failed':
+      return 'Google Calendar authorization could not be completed. Please connect again.';
+    default:
+      return 'Google Calendar connection failed. Please try again.';
+  }
+}
+
 export async function startGoogleCalendarOAuth(): Promise<boolean> {
   const {
     data: { session },
@@ -53,7 +66,13 @@ export async function startGoogleCalendarOAuth(): Promise<boolean> {
     return false;
   }
 
-  return result.url.includes('connected=true');
+  const callbackUrl = new URL(result.url);
+  const callbackError = callbackUrl.searchParams.get('error');
+  if (callbackError) {
+    throw new Error(getOAuthCallbackErrorMessage(callbackError));
+  }
+
+  return callbackUrl.searchParams.get('connected') === 'true';
 }
 
 export async function loadGoogleCalendarOAuthReturnUrl(): Promise<string | null> {

--- a/src/app/api/calendar/google/callback/route.ts
+++ b/src/app/api/calendar/google/callback/route.ts
@@ -2,6 +2,10 @@ import { logger } from '@/utils/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { GoogleCalendarService } from '@/services/googleCalendarService';
+import {
+    getGoogleOAuthClientId,
+    getGoogleOAuthClientSecret,
+} from '@/services/googleCalendarOAuthConfig';
 import { encryptToken } from '@/utils/tokenEncryption';
 import crypto from 'crypto';
 
@@ -59,8 +63,8 @@ async function handleCallback(request: NextRequest) {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
             body: new URLSearchParams({
-                client_id: process.env.GOOGLE_OAUTH_CLIENT_ID!,
-                client_secret: process.env.GOOGLE_OAUTH_CLIENT_SECRET!,
+                client_id: getGoogleOAuthClientId(),
+                client_secret: getGoogleOAuthClientSecret(),
                 code,
                 grant_type: 'authorization_code',
                 redirect_uri: `${origin}/api/calendar/google/callback`,

--- a/src/app/api/calendar/google/start/route.ts
+++ b/src/app/api/calendar/google/start/route.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+import { getGoogleOAuthClientId } from '@/services/googleCalendarOAuthConfig';
 import type { SubscriptionStatus } from '@/types/subscription';
 
 const OAUTH_STATE_COOKIE = 'calendar_oauth_state';
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest) {
         const origin = new URL(request.url).origin;
         const state = crypto.randomUUID();
         const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
-        authUrl.searchParams.set('client_id', process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || '');
+        authUrl.searchParams.set('client_id', getGoogleOAuthClientId());
         authUrl.searchParams.set('redirect_uri', `${origin}/api/calendar/google/callback`);
         authUrl.searchParams.set('response_type', 'code');
         authUrl.searchParams.set('scope', 'https://www.googleapis.com/auth/calendar');

--- a/src/app/api/mobile/calendar/google/callback/route.ts
+++ b/src/app/api/mobile/calendar/google/callback/route.ts
@@ -3,13 +3,12 @@ import { NextResponse } from 'next/server';
 
 import { CalendarConnectionService } from '@/services/calendarConnectionService';
 import { GoogleCalendarService } from '@/services/googleCalendarService';
-import { createAdminClient } from '@/utils/supabase/server';
-
 import {
   getGoogleOAuthClientId,
   getGoogleOAuthClientSecret,
-  getStateSecret,
-} from '../start/route';
+  getGoogleOAuthStateSecret,
+} from '@/services/googleCalendarOAuthConfig';
+import { createAdminClient } from '@/utils/supabase/server';
 
 interface OAuthStatePayload {
   expiresAt: number;
@@ -34,7 +33,7 @@ function decodeState(state: string | null): OAuthStatePayload | null {
   }
 
   const expectedSignature = crypto
-    .createHmac('sha256', getStateSecret())
+    .createHmac('sha256', getGoogleOAuthStateSecret())
     .update(body)
     .digest('base64url');
 

--- a/src/app/api/mobile/calendar/google/start/route.ts
+++ b/src/app/api/mobile/calendar/google/start/route.ts
@@ -6,34 +6,13 @@ import {
   requireCalendarSyncEntitlement,
   requireMobileAuth,
 } from '../_shared';
+import {
+  getGoogleOAuthClientId,
+  getGoogleOAuthClientSecret,
+  getGoogleOAuthStateSecret,
+} from '@/services/googleCalendarOAuthConfig';
 
 const OAUTH_STATE_TTL_SECONDS = 10 * 60;
-
-function getRequiredEnv(name: string) {
-  const value = process.env[name]?.trim();
-  if (!value) {
-    throw new Error(`${name} is not configured.`);
-  }
-
-  return value;
-}
-
-function getGoogleOAuthClientId() {
-  return getRequiredEnv('GOOGLE_OAUTH_CLIENT_ID');
-}
-
-function getGoogleOAuthClientSecret() {
-  return getRequiredEnv('GOOGLE_OAUTH_CLIENT_SECRET');
-}
-
-function getStateSecret() {
-  return (
-    process.env.GOOGLE_OAUTH_CLIENT_SECRET ||
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    process.env.NEXTAUTH_SECRET ||
-    getRequiredEnv('GOOGLE_OAUTH_CLIENT_SECRET')
-  );
-}
 
 function encodeState(payload: {
   expiresAt: number;
@@ -42,7 +21,7 @@ function encodeState(payload: {
 }) {
   const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
   const signature = crypto
-    .createHmac('sha256', getStateSecret())
+    .createHmac('sha256', getGoogleOAuthStateSecret())
     .update(body)
     .digest('base64url');
 
@@ -129,5 +108,3 @@ export async function GET(request: Request) {
     );
   }
 }
-
-export { getGoogleOAuthClientId, getGoogleOAuthClientSecret, getStateSecret };

--- a/src/components/dashboard/CalendarIntegrationSettings.tsx
+++ b/src/components/dashboard/CalendarIntegrationSettings.tsx
@@ -7,7 +7,8 @@
 
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { BrandLoadingLogo } from '@/components/brand/BrandLoadingLogo';
 import { useSnackbar } from '@/contexts/SnackbarContext';
 import { MaterialIcon } from '@/components/ui/Icon';
@@ -27,6 +28,8 @@ interface CalendarStatus {
 }
 
 export default function CalendarIntegrationSettings() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
     const [status, setStatus] = useState<CalendarStatus | null>(null);
     const [loading, setLoading] = useState(true);
     const [connecting, setConnecting] = useState(false);
@@ -34,6 +37,7 @@ export default function CalendarIntegrationSettings() {
     const [bulkSyncing, setBulkSyncing] = useState(false);
     const [showUpgradeModal, setShowUpgradeModal] = useState(false);
     const [upgradeVariant, setUpgradeVariant] = useState<'trialStart' | 'featureLocked' | 'upgradePrompt'>('featureLocked');
+    const handledCallbackResult = useRef(false);
     const { showSuccess, showError } = useSnackbar();
     const {
         isPro,
@@ -68,6 +72,35 @@ export default function CalendarIntegrationSettings() {
     useEffect(() => {
         fetchStatus();
     }, [fetchStatus]);
+
+    useEffect(() => {
+        if (handledCallbackResult.current) {
+            return;
+        }
+
+        const connected = searchParams.get('connected') === 'true';
+        const callbackError = searchParams.get('error');
+        if (!connected && !callbackError) {
+            return;
+        }
+
+        handledCallbackResult.current = true;
+        if (connected) {
+            showSuccess('Google Calendar connected successfully');
+        } else {
+            const errorMessages: Record<string, string> = {
+                callback_error: 'Google Calendar connection failed. Please try again.',
+                invalid_request: 'Google Calendar authorization expired. Please connect again.',
+                missing_tokens: 'Google did not provide the required calendar permissions. Please connect again.',
+                not_authenticated: 'Your session expired before calendar connection completed. Please sign in again.',
+                oauth_error: 'Google Calendar authorization was cancelled or denied.',
+                token_exchange_failed: 'Google Calendar authorization could not be completed. Please connect again.',
+            };
+            showError(errorMessages[callbackError ?? ''] ?? 'Google Calendar connection failed. Please try again.');
+        }
+
+        router.replace('/dashboard/settings?tab=integrations', { scroll: false });
+    }, [router, searchParams, showError, showSuccess]);
 
     const requireProAccess = (): boolean => {
         if (isPro || isTrialing) return true;

--- a/src/services/calendarConnectionService.ts
+++ b/src/services/calendarConnectionService.ts
@@ -108,17 +108,13 @@ export class CalendarConnectionService {
                 .select('*')
                 .eq('user_id', userId)
                 .eq('provider', provider)
-                .single();
+                .maybeSingle();
 
             if (error) {
-                if (error.code === 'PGRST116') {
-                    // No rows returned
-                    return null;
-                }
                 throw error;
             }
 
-            return data as CalendarConnection;
+            return data as CalendarConnection | null;
         } catch (error) {
             console.error('Error getting calendar connection:', error);
             Sentry.captureException(error, {

--- a/src/services/googleCalendarOAuthConfig.ts
+++ b/src/services/googleCalendarOAuthConfig.ts
@@ -1,0 +1,25 @@
+function getRequiredEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is not configured.`);
+  }
+
+  return value;
+}
+
+export function getGoogleOAuthClientId() {
+  return getRequiredEnv('GOOGLE_OAUTH_CLIENT_ID');
+}
+
+export function getGoogleOAuthClientSecret() {
+  return getRequiredEnv('GOOGLE_OAUTH_CLIENT_SECRET');
+}
+
+export function getGoogleOAuthStateSecret() {
+  return (
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET?.trim() ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY?.trim() ||
+    process.env.NEXTAUTH_SECRET?.trim() ||
+    getGoogleOAuthClientSecret()
+  );
+}


### PR DESCRIPTION
## Summary
- Standardize web and mobile Google Calendar OAuth routes on server-owned OAuth client configuration.
- Surface callback outcomes consistently and avoid a missing-connection status error.
- Redesign the mobile Calendar integration card as a compact inline Google row with vector branding, sync, and disconnect actions.
- Document the required mobile Google OAuth redirect URI setup.

## Root cause
OAuth start and callback handling could use inconsistent Google client configuration. The web callback failure also exposed invalid local token encryption configuration, while mobile callback errors and the connected-state UI needed clearer handling.

## Validation
- `npm test -- --run src/app/api/mobile/calendar/google/route.test.ts apps/mobile/src/lib/googleCalendarOAuth.test.ts` (15 tests passed)
- `npm run type-check:src`
- `npm run type-check:mobile`
- focused `eslint` on changed TypeScript/TSX files
- `git diff --check` on the scoped changes
