### PR TITLE
[codex] Add mobile event reviews and agenda networking pulse

### DIFF
--- a/apps/mobile/app/event/[id].tsx
+++ b/apps/mobile/app/event/[id].tsx
@@ -7,10 +7,16 @@ import type {
   MobileCalendarConnectionStatus,
   MobileEventDetail,
   MobileEventEngagement,
+  MobileEventNetworkingFeedback,
+  MobileEventNetworkingFeedbackUpdate,
 } from '@kurecal/domain';
 
 import { MobileEventDetailScreen } from '../../src/components/event-detail/MobileEventDetailScreen';
-import { buildMapsSearchUrl } from '../../src/components/event-detail/eventDetailUtils';
+import { EventReviewSheet } from '../../src/components/event-detail/EventReviewSheet';
+import {
+  buildMapsSearchUrl,
+  getAttendanceCtaState,
+} from '../../src/components/event-detail/eventDetailUtils';
 import { ScreenStateView } from '../../src/components/ScreenStateView';
 import {
   getDeviceCalendarMapping,
@@ -20,10 +26,13 @@ import {
 } from '../../src/lib/deviceCalendarSync';
 import {
   loadMobileEventDetail,
+  loadMobileEventNetworkingFeedback,
   loadMobileGoogleCalendarStatus,
   syncMobileGoogleCalendarEvent,
   unsyncMobileGoogleCalendarEvent,
+  updateMobileEventAgendaSave,
   updateMobileEventEngagement,
+  updateMobileEventNetworkingFeedback,
 } from '../../src/lib/mobileApi';
 
 export default function EventDetailRoute() {
@@ -36,6 +45,13 @@ export default function EventDetailRoute() {
   const [loading, setLoading] = useState(true);
   const [bookmarkPending, setBookmarkPending] = useState(false);
   const [attendancePending, setAttendancePending] = useState(false);
+  const [reviewVisible, setReviewVisible] = useState(false);
+  const [reviewLoading, setReviewLoading] = useState(false);
+  const [reviewFeedback, setReviewFeedback] =
+    useState<MobileEventNetworkingFeedback | null>(null);
+  const [pendingAgendaSaveIds, setPendingAgendaSaveIds] = useState<Set<string>>(
+    () => new Set()
+  );
   const [calendarPending, setCalendarPending] = useState(false);
   const [googleStatus, setGoogleStatus] =
     useState<MobileCalendarConnectionStatus | null>(null);
@@ -378,13 +394,40 @@ export default function EventDetailRoute() {
     }
   }
 
+  async function openReviewSheet() {
+    if (!data) {
+      return;
+    }
+
+    setReviewVisible(true);
+    setReviewLoading(true);
+    try {
+      setReviewFeedback(await loadMobileEventNetworkingFeedback(data.event.id));
+    } catch (nextError) {
+      console.warn('Unable to load existing event review', nextError);
+      setReviewFeedback(null);
+    } finally {
+      setReviewLoading(false);
+    }
+  }
+
   async function handleToggleAttendance() {
     if (!data || attendancePending) {
       return;
     }
 
+    const action = getAttendanceCtaState(data.event, data.event.engagement).action;
+    if (action === 'review') {
+      await openReviewSheet();
+      return;
+    }
+
     const nextStatus =
-      data.event.engagement?.status === 'attending' ? null : 'attending';
+      action === 'confirm-attended'
+        ? 'attended'
+        : data.event.engagement?.status === 'attending'
+          ? null
+          : 'attending';
     setAttendancePending(true);
 
     try {
@@ -394,6 +437,9 @@ export default function EventDetailRoute() {
 
       updateEngagementState(engagement);
       void syncGoogleAfterEngagementChange(engagement);
+      if (nextStatus === 'attended') {
+        await openReviewSheet();
+      }
     } catch (nextError) {
       Alert.alert(
         'Unable to update attendance',
@@ -401,6 +447,63 @@ export default function EventDetailRoute() {
       );
     } finally {
       setAttendancePending(false);
+    }
+  }
+
+  async function handleRemoveAttendance() {
+    if (!data || attendancePending) {
+      return;
+    }
+
+    setAttendancePending(true);
+    try {
+      const engagement = await updateMobileEventEngagement(data.event.id, {
+        status: null,
+      });
+      updateEngagementState(engagement);
+      void syncGoogleAfterEngagementChange(engagement);
+    } catch (nextError) {
+      Alert.alert(
+        'Unable to remove attendance',
+        nextError instanceof Error ? nextError.message : 'Please try again.'
+      );
+    } finally {
+      setAttendancePending(false);
+    }
+  }
+
+  async function handleSubmitReview(input: MobileEventNetworkingFeedbackUpdate) {
+    if (!data || input.actualValueRating == null) {
+      throw new Error('Select a rating to submit your review.');
+    }
+
+    const feedback = await updateMobileEventNetworkingFeedback(data.event.id, input);
+    setReviewFeedback(feedback);
+    setReviewVisible(false);
+  }
+
+  async function handleToggleAgendaSave(agendaItemId: string, isSaved: boolean) {
+    if (!data || pendingAgendaSaveIds.has(agendaItemId)) {
+      return;
+    }
+
+    setPendingAgendaSaveIds((current) => new Set(current).add(agendaItemId));
+
+    try {
+      await updateMobileEventAgendaSave(data.event.id, agendaItemId, isSaved);
+      const nextDetail = await loadMobileEventDetail(data.event.id);
+      setData(nextDetail);
+    } catch (nextError) {
+      Alert.alert(
+        isSaved ? 'Unable to save session' : 'Unable to remove saved session',
+        nextError instanceof Error ? nextError.message : 'Please try again.'
+      );
+    } finally {
+      setPendingAgendaSaveIds((current) => {
+        const next = new Set(current);
+        next.delete(agendaItemId);
+        return next;
+      });
     }
   }
 
@@ -461,37 +564,56 @@ export default function EventDetailRoute() {
         : googleStatus?.requiresUpgrade
           ? 'warning'
           : 'neutral';
+  const attendanceCta = getAttendanceCtaState(data.event, data.event.engagement);
 
   return (
-    <MobileEventDetailScreen
-      detail={data}
-      engagement={data.event.engagement}
-      isBookmarkPending={bookmarkPending}
-      isAttendancePending={attendancePending}
-      calendarStatusLabel={calendarStatusLabel}
-      calendarStatusTone={calendarStatusTone}
-      onBack={() => router.back()}
-      onPrimaryAction={() => {
-        void handlePrimaryAction();
-      }}
-      onAddToCalendar={() => {
-        handleAddToCalendar();
-      }}
-      onToggleBookmark={() => {
-        void handleToggleBookmark();
-      }}
-      onToggleAttendance={() => {
-        void handleToggleAttendance();
-      }}
-      onOpenEventPage={() => {
-        void openUrl(data.event.sourceUrl);
-      }}
-      onOpenLocation={(location) => {
-        void openUrl(buildMapsSearchUrl(location));
-      }}
-      onShareEvent={() => {
-        void handleShareEvent();
-      }}
-    />
+    <>
+      <MobileEventDetailScreen
+        attendanceCta={attendanceCta}
+        detail={data}
+        engagement={data.event.engagement}
+        isBookmarkPending={bookmarkPending}
+        isAttendancePending={attendancePending}
+        pendingAgendaSaveIds={pendingAgendaSaveIds}
+        calendarStatusLabel={calendarStatusLabel}
+        calendarStatusTone={calendarStatusTone}
+        onBack={() => router.back()}
+        onPrimaryAction={() => {
+          void handlePrimaryAction();
+        }}
+        onAddToCalendar={() => {
+          handleAddToCalendar();
+        }}
+        onToggleBookmark={() => {
+          void handleToggleBookmark();
+        }}
+        onToggleAttendance={() => {
+          void handleToggleAttendance();
+        }}
+        onRemoveAttendance={() => {
+          void handleRemoveAttendance();
+        }}
+        onToggleAgendaSave={(agendaItemId, isSaved) => {
+          void handleToggleAgendaSave(agendaItemId, isSaved);
+        }}
+        onOpenEventPage={() => {
+          void openUrl(data.event.sourceUrl);
+        }}
+        onOpenLocation={(location) => {
+          void openUrl(buildMapsSearchUrl(location));
+        }}
+        onShareEvent={() => {
+          void handleShareEvent();
+        }}
+      />
+      <EventReviewSheet
+        eventTitle={data.event.title}
+        feedback={reviewFeedback}
+        isLoading={reviewLoading}
+        onDismiss={() => setReviewVisible(false)}
+        onSubmit={handleSubmitReview}
+        visible={reviewVisible}
+      />
+    </>
   );
 }

--- a/apps/mobile/src/components/event-detail/EventReviewSheet.tsx
+++ b/apps/mobile/src/components/event-detail/EventReviewSheet.tsx
@@ -1,0 +1,256 @@
+import type {
+  MobileEventNetworkingFeedback,
+  MobileEventNetworkingFeedbackUpdate,
+} from '@kurecal/domain';
+import { FontAwesome } from '@expo/vector-icons';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { useAppTheme } from '../../providers/ThemeProvider';
+
+export function EventReviewSheet({
+  eventTitle,
+  feedback,
+  isLoading,
+  onDismiss,
+  onSubmit,
+  visible,
+}: {
+  eventTitle: string;
+  feedback: MobileEventNetworkingFeedback | null;
+  isLoading: boolean;
+  onDismiss: () => void;
+  onSubmit: (input: MobileEventNetworkingFeedbackUpdate) => Promise<void>;
+  visible: boolean;
+}) {
+  const { tokens } = useAppTheme();
+  const [rating, setRating] = useState<number | null>(null);
+  const [connectionsMade, setConnectionsMade] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setRating(feedback?.actualValueRating ?? null);
+      setConnectionsMade(feedback?.connectionsMade ?? null);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [feedback, visible]);
+
+  async function handleSubmit() {
+    if (rating === null) {
+      setError('Select a rating to submit your review.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        actualValueRating: rating,
+        ...(connectionsMade !== null ? { connectionsMade } : {}),
+      });
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error ? nextError.message : 'Unable to save review.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onDismiss}
+      transparent
+      visible={visible}
+    >
+      <Pressable
+        accessibilityLabel="Close event review"
+        onPress={onDismiss}
+        style={[styles.overlay, { backgroundColor: tokens.colors.overlay }]}
+      />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: tokens.colors.shellElevated,
+              borderTopColor: tokens.colors.borderStrong,
+            },
+          ]}
+        >
+          <View style={[styles.dragHandle, { backgroundColor: tokens.colors.borderStrong }]} />
+          <Text style={[styles.title, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+            How was this event?
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={[styles.subtitle, { color: tokens.colors.textSecondary, fontFamily: tokens.typography.sans }]}
+          >
+            {eventTitle}
+          </Text>
+
+          {isLoading ? (
+            <View style={styles.loading}>
+              <ActivityIndicator color={tokens.colors.accent} />
+            </View>
+          ) : (
+            <>
+              <View style={styles.field}>
+                <Text style={[styles.label, { color: tokens.colors.textSecondary, fontFamily: tokens.typography.sans }]}>
+                  Rating
+                </Text>
+                <View style={styles.ratingRow}>
+                  {[1, 2, 3, 4, 5].map((value) => {
+                    const selected = rating !== null && value <= rating;
+                    return (
+                      <Pressable
+                        accessibilityLabel={`Rate ${value} out of 5`}
+                        key={value}
+                        onPress={() => setRating(value)}
+                        style={({ pressed }) => [
+                          styles.ratingButton,
+                          {
+                            backgroundColor: selected ? tokens.colors.accentSoft : tokens.colors.surface,
+                            borderColor: selected ? tokens.colors.accent : tokens.colors.border,
+                            opacity: pressed ? 0.76 : 1,
+                          },
+                        ]}
+                      >
+                        <FontAwesome
+                          color={selected ? tokens.colors.accent : tokens.colors.textTertiary}
+                          name={selected ? 'star' : 'star-o'}
+                          size={16}
+                        />
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View style={[styles.field, styles.connectionsField, { borderTopColor: tokens.colors.divider }]}>
+                <View style={styles.connectionsCopy}>
+                  <Text style={[styles.label, { color: tokens.colors.textSecondary, fontFamily: tokens.typography.sans }]}>
+                    Connections made
+                  </Text>
+                  <Text style={[styles.hint, { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans }]}>
+                    Optional
+                  </Text>
+                </View>
+                {connectionsMade === null ? (
+                  <Pressable
+                    onPress={() => setConnectionsMade(0)}
+                    style={[styles.trackButton, { borderColor: tokens.colors.borderStrong }]}
+                  >
+                    <Text style={[styles.trackLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                      Add count
+                    </Text>
+                  </Pressable>
+                ) : (
+                  <View style={styles.stepper}>
+                    <Pressable
+                      accessibilityLabel="Decrease connections made"
+                      onPress={() => setConnectionsMade((current) => Math.max(0, (current ?? 0) - 1))}
+                      style={[styles.stepButton, { borderColor: tokens.colors.borderStrong }]}
+                    >
+                      <FontAwesome name="minus" size={11} color={tokens.colors.textSecondary} />
+                    </Pressable>
+                    <Text style={[styles.count, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.mono }]}>
+                      {connectionsMade}
+                    </Text>
+                    <Pressable
+                      accessibilityLabel="Increase connections made"
+                      onPress={() => setConnectionsMade((current) => (current ?? 0) + 1)}
+                      style={[styles.stepButton, { borderColor: tokens.colors.borderStrong }]}
+                    >
+                      <FontAwesome name="plus" size={11} color={tokens.colors.textSecondary} />
+                    </Pressable>
+                  </View>
+                )}
+              </View>
+              {error ? (
+                <Text style={[styles.error, { color: tokens.colors.danger, fontFamily: tokens.typography.sans }]}>
+                  {error}
+                </Text>
+              ) : null}
+            </>
+          )}
+
+          <View style={[styles.footer, { borderTopColor: tokens.colors.divider }]}>
+            <Pressable
+              disabled={submitting}
+              onPress={onDismiss}
+              style={[styles.secondaryButton, { borderColor: tokens.colors.borderStrong }]}
+            >
+              <Text style={[styles.buttonLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                Not now
+              </Text>
+            </Pressable>
+            <Pressable
+              disabled={isLoading || submitting}
+              onPress={() => void handleSubmit()}
+              style={[
+                styles.primaryButton,
+                {
+                  backgroundColor: tokens.colors.accent,
+                  opacity: isLoading || submitting ? 0.5 : 1,
+                },
+              ]}
+            >
+              {submitting ? (
+                <ActivityIndicator color={tokens.colors.textInverse} size="small" />
+              ) : (
+                <Text style={[styles.buttonLabel, { color: tokens.colors.textInverse, fontFamily: tokens.typography.sans }]}>
+                  Submit review
+                </Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonLabel: { fontSize: 13, fontWeight: '700' },
+  connectionsCopy: { flex: 1, gap: 2 },
+  connectionsField: {
+    alignItems: 'center',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    paddingTop: 16,
+  },
+  count: { fontSize: 15, fontVariant: ['tabular-nums'], fontWeight: '700', minWidth: 28, textAlign: 'center' },
+  dragHandle: { alignSelf: 'center', borderRadius: 2, height: 4, marginBottom: 16, width: 36 },
+  error: { fontSize: 12, lineHeight: 17, paddingHorizontal: 16, paddingTop: 12 },
+  field: { gap: 12, paddingHorizontal: 16, paddingVertical: 16 },
+  footer: { borderTopWidth: StyleSheet.hairlineWidth, flexDirection: 'row', gap: 10, padding: 16 },
+  hint: { fontSize: 12, lineHeight: 16 },
+  label: { fontSize: 13, fontWeight: '600', lineHeight: 18 },
+  loading: { alignItems: 'center', height: 146, justifyContent: 'center' },
+  overlay: { ...StyleSheet.absoluteFillObject },
+  primaryButton: { alignItems: 'center', borderRadius: 6, flex: 1, justifyContent: 'center', minHeight: 38 },
+  ratingButton: { alignItems: 'center', borderRadius: 5, borderWidth: 1, flex: 1, height: 42, justifyContent: 'center' },
+  ratingRow: { flexDirection: 'row', gap: 8 },
+  safeArea: { flex: 1, justifyContent: 'flex-end' },
+  secondaryButton: { alignItems: 'center', borderRadius: 6, borderWidth: 1, flex: 1, justifyContent: 'center', minHeight: 38 },
+  sheet: { borderTopLeftRadius: 10, borderTopRightRadius: 10, borderTopWidth: 1, paddingTop: 10 },
+  stepButton: { alignItems: 'center', borderRadius: 5, borderWidth: 1, height: 32, justifyContent: 'center', width: 32 },
+  stepper: { alignItems: 'center', flexDirection: 'row', gap: 8 },
+  subtitle: { fontSize: 13, lineHeight: 18, paddingHorizontal: 16, paddingTop: 4 },
+  title: { fontSize: 18, fontWeight: '700', lineHeight: 23, paddingHorizontal: 16 },
+  trackButton: { borderRadius: 5, borderWidth: 1, minHeight: 32, justifyContent: 'center', paddingHorizontal: 12 },
+  trackLabel: { fontSize: 12, fontWeight: '600' },
+});

--- a/apps/mobile/src/components/event-detail/MobileEventDetailScreen.tsx
+++ b/apps/mobile/src/components/event-detail/MobileEventDetailScreen.tsx
@@ -24,6 +24,7 @@ import {
   getInitials,
   hasMappableLocation,
   SPEAKER_PREVIEW_COUNT,
+  type AttendanceCtaState,
 } from './eventDetailUtils';
 import { KureButton } from '../chrome/KureButton';
 import { useAppTheme } from '../../providers/ThemeProvider';
@@ -33,7 +34,7 @@ function IconMetaRow({
   children,
   onPress,
 }: {
-  icon: string;
+  icon: keyof typeof FontAwesome.glyphMap;
   children: ReactNode;
   onPress?: () => void;
 }) {
@@ -41,7 +42,7 @@ function IconMetaRow({
 
   const inner = (
     <View style={styles.iconMetaRow}>
-      <FontAwesome name={icon as any} size={13} color={tokens.colors.textTertiary} style={styles.iconMetaIcon} />
+      <FontAwesome name={icon} size={13} color={tokens.colors.textTertiary} style={styles.iconMetaIcon} />
       <View style={{ flex: 1 }}>{children}</View>
     </View>
   );
@@ -63,18 +64,98 @@ function IconMetaRow({
   return <View style={styles.iconMetaRowPressable}>{inner}</View>;
 }
 
+function NetworkingPulseSection({
+  pulse,
+}: {
+  pulse: NonNullable<MobileEventDetail['networkingPulse']>;
+}) {
+  const { tokens } = useAppTheme();
+  const hasActiveSignal =
+    pulse.state === 'active' && (pulse.trendingTopic || pulse.mostSavedSession);
+
+  if (!hasActiveSignal) {
+    return null;
+  }
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionHeader}>
+        <Text style={[styles.sectionTitle, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+          What attendees are focusing on
+        </Text>
+      </View>
+
+      <View style={styles.pulseGrid}>
+          {pulse.trendingTopic ? (
+            <View
+              style={[
+                styles.pulseMetric,
+                {
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: tokens.colors.border,
+                },
+              ]}
+            >
+              <Text style={[styles.pulseLabel, { color: tokens.colors.accent, fontFamily: tokens.typography.sans }]}>
+                Trending topic
+              </Text>
+              <Text numberOfLines={1} style={[styles.pulseValue, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                {pulse.trendingTopic.label}
+              </Text>
+              <View style={styles.pulseMetaRow}>
+                <FontAwesome name="line-chart" size={13} color={tokens.colors.textSecondary} />
+                <Text style={[styles.pulseMeta, { color: tokens.colors.textSecondary, fontFamily: tokens.typography.sans }]}>
+                  {pulse.trendingTopic.activityLabel}
+                </Text>
+              </View>
+            </View>
+          ) : null}
+
+          {pulse.mostSavedSession ? (
+            <View
+              style={[
+                styles.pulseMetric,
+                {
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: tokens.colors.border,
+                },
+              ]}
+            >
+              <Text style={[styles.pulseLabel, { color: tokens.colors.accent, fontFamily: tokens.typography.sans }]}>
+                Most saved session
+              </Text>
+              <Text numberOfLines={1} style={[styles.pulseValue, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                {pulse.mostSavedSession.title}
+              </Text>
+              <View style={styles.pulseMetaRow}>
+                <FontAwesome name="bookmark-o" size={13} color={tokens.colors.textSecondary} />
+                <Text style={[styles.pulseMeta, { color: tokens.colors.textSecondary, fontFamily: tokens.typography.sans }]}>
+                  {pulse.mostSavedSession.saveCount} saves
+                </Text>
+              </View>
+            </View>
+          ) : null}
+      </View>
+    </View>
+  );
+}
+
 export function MobileEventDetailScreen({
   detail,
   engagement,
   isBookmarkPending = false,
   isAttendancePending = false,
+  attendanceCta,
   onBack,
   onPrimaryAction,
   onAddToCalendar,
   calendarStatusLabel,
   calendarStatusTone = 'neutral',
+  pendingAgendaSaveIds,
   onToggleBookmark,
   onToggleAttendance,
+  onRemoveAttendance,
+  onToggleAgendaSave,
   onOpenEventPage,
   onOpenLocation,
   onShareEvent,
@@ -83,13 +164,17 @@ export function MobileEventDetailScreen({
   engagement?: MobileEventEngagement;
   isBookmarkPending?: boolean;
   isAttendancePending?: boolean;
+  attendanceCta: AttendanceCtaState;
   onBack: () => void;
   onPrimaryAction: () => void;
   onAddToCalendar: () => void;
   calendarStatusLabel?: string | null;
   calendarStatusTone?: 'neutral' | 'success' | 'warning' | 'danger';
+  pendingAgendaSaveIds?: Set<string>;
   onToggleBookmark: () => void;
   onToggleAttendance: () => void;
+  onRemoveAttendance: () => void;
+  onToggleAgendaSave?: (agendaItemId: string, isSaved: boolean) => void;
   onOpenEventPage: () => void;
   onOpenLocation: (location: string) => void;
   onShareEvent: () => void;
@@ -104,8 +189,8 @@ export function MobileEventDetailScreen({
   const event = detail.event;
   const host = detail.host;
   const tags = detail.tags ?? [];
-  const agenda = detail.agenda ?? [];
-  const speakerLineup = detail.speakerLineup ?? [];
+  const agenda = useMemo(() => detail.agenda ?? [], [detail.agenda]);
+  const networkingPulse = detail.networkingPulse;
   const agendaDayGroups = useMemo(
     () => buildAgendaDayGroups(agenda, event.timezone),
     [agenda, event.timezone]
@@ -124,6 +209,7 @@ export function MobileEventDetailScreen({
   const primaryLabel = hasPrimaryUrl ? 'Register' : 'Add to calendar';
   const isLocationInteractive = hasMappableLocation(event.location);
   const isAttending = engagement?.status === 'attending';
+  const isAttended = engagement?.status === 'attended';
   const isBookmarked = Boolean(engagement?.isBookmarked);
   const calendarStatusColor =
     calendarStatusTone === 'success'
@@ -166,28 +252,146 @@ export function MobileEventDetailScreen({
           ]}
         >
           <View style={styles.headerRow}>
-            <Pressable
-              accessibilityLabel="Back"
-              onPress={onBack}
-              style={({ pressed }) => [
-                styles.iconButton,
-                { backgroundColor: pressed ? tokens.colors.surfaceStrong : 'transparent' },
-              ]}
-            >
-              <FontAwesome name="angle-left" size={22} color={tokens.colors.textSecondary} />
-            </Pressable>
-
-            <View style={styles.headerCopy}>
-              {event.metaLabel ? (
-                <Text
-                  style={[
-                    styles.headerEyebrow,
-                    { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans },
+            <View style={styles.headerControls}>
+              <Pressable
+                accessibilityLabel="Back"
+                onPress={onBack}
+                style={({ pressed }) => [
+                  styles.headerBackButton,
+                  { backgroundColor: pressed ? tokens.colors.surfaceStrong : 'transparent' },
+                ]}
+              >
+                <FontAwesome name="angle-left" size={20} color={tokens.colors.textSecondary} />
+              </Pressable>
+              <View style={styles.headerActions}>
+                <Pressable
+                  accessibilityLabel={isBookmarked ? 'Remove saved event' : 'Save event'}
+                  disabled={isBookmarkPending}
+                  onPress={onToggleBookmark}
+                  style={({ pressed }) => [
+                    styles.iconButton,
+                    styles.iconStateButton,
+                    {
+                      backgroundColor: isBookmarked
+                        ? tokens.colors.warning
+                        : pressed
+                          ? tokens.colors.surfaceStrong
+                          : tokens.colors.surface,
+                      borderColor: isBookmarked ? tokens.colors.warning : tokens.colors.border,
+                      opacity: isBookmarkPending ? 0.45 : 1,
+                    },
                   ]}
                 >
-                  {event.metaLabel}
-                </Text>
-              ) : null}
+                  <FontAwesome
+                    name={isBookmarked ? 'bookmark' : 'bookmark-o'}
+                    size={15}
+                    color={isBookmarked ? tokens.colors.textInverse : tokens.colors.textSecondary}
+                  />
+                </Pressable>
+
+                <Pressable
+                  accessibilityLabel="More actions"
+                  onPress={() => setShowMenu((current) => !current)}
+                  style={({ pressed }) => [
+                    styles.iconButton,
+                    { backgroundColor: pressed ? tokens.colors.surfaceStrong : 'transparent' },
+                  ]}
+                >
+                  <FontAwesome name="ellipsis-v" size={16} color={tokens.colors.textSecondary} />
+                </Pressable>
+
+                {showMenu ? (
+                  <View
+                    style={[
+                      styles.menu,
+                      {
+                        backgroundColor: tokens.colors.surface,
+                        borderColor: tokens.colors.borderStrong,
+                      },
+                    ]}
+                  >
+                    <Pressable
+                      onPress={() => { setShowMenu(false); onShareEvent(); }}
+                      style={({ pressed }) => [
+                        styles.menuItem,
+                        { backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent' },
+                      ]}
+                    >
+                      <FontAwesome name="share-alt" size={14} color={tokens.colors.textSecondary} />
+                      <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                        Share event
+                      </Text>
+                    </Pressable>
+
+                    <Pressable
+                      onPress={() => { setShowMenu(false); onAddToCalendar(); }}
+                      style={({ pressed }) => [
+                        styles.menuItem,
+                        { backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent' },
+                      ]}
+                    >
+                      <FontAwesome name="calendar-plus-o" size={14} color={tokens.colors.textSecondary} />
+                      <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                        Add to calendar
+                      </Text>
+                    </Pressable>
+
+                    {canOpenEventPage ? (
+                      <Pressable
+                        onPress={() => { setShowMenu(false); onOpenEventPage(); }}
+                        style={({ pressed }) => [
+                          styles.menuItem,
+                          { backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent' },
+                        ]}
+                      >
+                        <FontAwesome name="external-link" size={13} color={tokens.colors.textSecondary} />
+                        <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                          Visit event page
+                        </Text>
+                      </Pressable>
+                    ) : null}
+
+                    {isAttended ? (
+                      <Pressable
+                        disabled={isAttendancePending}
+                        onPress={() => { setShowMenu(false); onRemoveAttendance(); }}
+                        style={({ pressed }) => [
+                          styles.menuItem,
+                          {
+                            backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent',
+                            opacity: isAttendancePending ? 0.45 : 1,
+                          },
+                        ]}
+                      >
+                        <FontAwesome name="times-circle-o" size={14} color={tokens.colors.textSecondary} />
+                        <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                          Remove attendance
+                        </Text>
+                      </Pressable>
+                    ) : (
+                      <Pressable
+                        disabled={isAttendancePending}
+                        onPress={() => { setShowMenu(false); onToggleAttendance(); }}
+                        style={({ pressed }) => [
+                          styles.menuItem,
+                          {
+                            backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent',
+                            opacity: isAttendancePending ? 0.45 : 1,
+                          },
+                        ]}
+                      >
+                        <FontAwesome name="check-circle-o" size={14} color={tokens.colors.textSecondary} />
+                        <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                          {isAttending ? 'Remove RSVP' : attendanceCta.label}
+                        </Text>
+                      </Pressable>
+                    )}
+                  </View>
+                ) : null}
+              </View>
+            </View>
+
+            <View style={styles.headerCopy}>
               <Text
                 testID="event-detail-title"
                 numberOfLines={2}
@@ -199,7 +403,6 @@ export function MobileEventDetailScreen({
                 {event.title}
               </Text>
 
-              {/* Compact meta cluster: badges + date + location */}
               <View style={styles.metaCluster}>
                 {event.formatLabel ? (
                   <View
@@ -227,114 +430,6 @@ export function MobileEventDetailScreen({
                 ) : null}
               </View>
             </View>
-
-            <View style={styles.headerActions}>
-              <Pressable
-                accessibilityLabel={isBookmarked ? 'Remove saved event' : 'Save event'}
-                disabled={isBookmarkPending}
-                onPress={onToggleBookmark}
-                style={({ pressed }) => [
-                  styles.iconButton,
-                  styles.iconStateButton,
-                  {
-                    backgroundColor: isBookmarked
-                      ? tokens.colors.warning
-                      : pressed
-                        ? tokens.colors.surfaceStrong
-                        : tokens.colors.surface,
-                    borderColor: isBookmarked ? tokens.colors.warning : tokens.colors.border,
-                    opacity: isBookmarkPending ? 0.45 : 1,
-                  },
-                ]}
-              >
-                <FontAwesome
-                  name={isBookmarked ? 'bookmark' : 'bookmark-o'}
-                  size={15}
-                  color={isBookmarked ? tokens.colors.textInverse : tokens.colors.textSecondary}
-                />
-              </Pressable>
-
-              <Pressable
-                accessibilityLabel="More actions"
-                onPress={() => setShowMenu((current) => !current)}
-                style={({ pressed }) => [
-                  styles.iconButton,
-                  { backgroundColor: pressed ? tokens.colors.surfaceStrong : 'transparent' },
-                ]}
-              >
-                <FontAwesome name="ellipsis-v" size={16} color={tokens.colors.textSecondary} />
-              </Pressable>
-
-              {showMenu ? (
-                <View
-                  style={[
-                    styles.menu,
-                    {
-                      backgroundColor: tokens.colors.surface,
-                      borderColor: tokens.colors.borderStrong,
-                    },
-                  ]}
-                >
-                  <Pressable
-                    onPress={() => { setShowMenu(false); onShareEvent(); }}
-                    style={({ pressed }) => [
-                      styles.menuItem,
-                      { backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent' },
-                    ]}
-                  >
-                    <FontAwesome name="share-alt" size={14} color={tokens.colors.textSecondary} />
-                    <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
-                      Share event
-                    </Text>
-                  </Pressable>
-
-                  <Pressable
-                    onPress={() => { setShowMenu(false); onAddToCalendar(); }}
-                    style={({ pressed }) => [
-                      styles.menuItem,
-                      { backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent' },
-                    ]}
-                  >
-                    <FontAwesome name="calendar-plus-o" size={14} color={tokens.colors.textSecondary} />
-                    <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
-                      Add to calendar
-                    </Text>
-                  </Pressable>
-
-                  {canOpenEventPage ? (
-                    <Pressable
-                      onPress={() => { setShowMenu(false); onOpenEventPage(); }}
-                      style={({ pressed }) => [
-                        styles.menuItem,
-                        { backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent' },
-                      ]}
-                    >
-                      <FontAwesome name="external-link" size={13} color={tokens.colors.textSecondary} />
-                      <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
-                        Visit event page
-                      </Text>
-                    </Pressable>
-                  ) : null}
-
-                  <Pressable
-                    disabled={isAttendancePending}
-                    onPress={() => { setShowMenu(false); onToggleAttendance(); }}
-                    style={({ pressed }) => [
-                      styles.menuItem,
-                      {
-                        backgroundColor: pressed ? tokens.colors.surfaceMuted : 'transparent',
-                        opacity: isAttendancePending ? 0.45 : 1,
-                      },
-                    ]}
-                  >
-                    <FontAwesome name="check-circle-o" size={14} color={tokens.colors.textSecondary} />
-                    <Text style={[styles.menuLabel, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
-                      {isAttending ? 'Remove RSVP' : 'Mark attending'}
-                    </Text>
-                  </Pressable>
-                </View>
-              ) : null}
-            </View>
           </View>
         </View>
 
@@ -344,10 +439,10 @@ export function MobileEventDetailScreen({
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          {/* Event meta sheet: date, location, organizer */}
+          {/* Event facts */}
           <View
             style={[
-              styles.metaSheet,
+              styles.factPanel,
               {
                 backgroundColor: tokens.colors.surface,
                 borderColor: tokens.colors.border,
@@ -355,7 +450,7 @@ export function MobileEventDetailScreen({
             ]}
           >
             <IconMetaRow icon="calendar">
-              <Text style={[styles.metaRowText, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+              <Text selectable style={[styles.metaRowText, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                 {formatEventDateTime(event.startTime, event.endTime, event.timezone)}
               </Text>
               {calendarStatusLabel ? (
@@ -377,7 +472,7 @@ export function MobileEventDetailScreen({
                   icon="map-marker"
                   onPress={isLocationInteractive ? () => onOpenLocation(event.location!) : undefined}
                 >
-                  <Text style={[styles.metaRowText, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                  <Text selectable style={[styles.metaRowText, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                     {event.location}
                   </Text>
                 </IconMetaRow>
@@ -407,7 +502,7 @@ export function MobileEventDetailScreen({
                       <Text style={[styles.organizerLabel, { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans }]}>
                         Organizer
                       </Text>
-                      <Text style={[styles.metaRowText, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
+                      <Text selectable style={[styles.metaRowText, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                         {host.name}
                       </Text>
                     </View>
@@ -417,18 +512,20 @@ export function MobileEventDetailScreen({
             ) : null}
           </View>
 
+          {networkingPulse ? (
+            <NetworkingPulseSection pulse={networkingPulse} />
+          ) : null}
+
           {/* Description */}
           {event.description ? (
             <View style={styles.section}>
               <View style={styles.sectionHeader}>
-                <Text style={[styles.sectionEyebrow, { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans }]}>
-                  Overview
-                </Text>
                 <Text style={[styles.sectionTitle, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                   What this event is about
                 </Text>
               </View>
               <Text
+                selectable
                 numberOfLines={showFullDescription ? undefined : 5}
                 style={[styles.sectionBody, { color: tokens.colors.textSecondary, fontFamily: tokens.typography.sans }]}
               >
@@ -448,9 +545,6 @@ export function MobileEventDetailScreen({
           {tags.length > 0 ? (
             <View style={styles.section}>
               <View style={styles.sectionHeader}>
-                <Text style={[styles.sectionEyebrow, { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans }]}>
-                  Focus areas
-                </Text>
                 <Text style={[styles.sectionTitle, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                   Tags
                 </Text>
@@ -495,27 +589,29 @@ export function MobileEventDetailScreen({
           {uniqueSpeakers.length > 0 ? (
             <View style={styles.section}>
               <View style={styles.sectionHeader}>
-                <Text style={[styles.sectionEyebrow, { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans }]}>
-                  Speakers
-                </Text>
                 <Text style={[styles.sectionTitle, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                   Who is on stage
                 </Text>
               </View>
 
-              <View style={styles.cardStack}>
-                {visibleSpeakers.map((speaker) => {
+              <View
+                style={[
+                  styles.listPanel,
+                  {
+                    backgroundColor: tokens.colors.surface,
+                    borderColor: tokens.colors.border,
+                  },
+                ]}
+              >
+                {visibleSpeakers.map((speaker, index) => {
                   const secondary = buildSpeakerSecondaryText(speaker);
 
                   return (
                     <View
                       key={speaker.id || speaker.name}
                       style={[
-                        styles.infoCard,
-                        {
-                          backgroundColor: tokens.colors.surface,
-                          borderColor: tokens.colors.border,
-                        },
+                        styles.speakerListRow,
+                        index > 0 && { borderTopColor: tokens.colors.divider, borderTopWidth: StyleSheet.hairlineWidth },
                       ]}
                     >
                       <View style={styles.speakerRow}>
@@ -563,15 +659,12 @@ export function MobileEventDetailScreen({
           {agendaDayGroups.length > 0 ? (
             <View style={styles.section}>
               <View style={styles.sectionHeader}>
-                <Text style={[styles.sectionEyebrow, { color: tokens.colors.textTertiary, fontFamily: tokens.typography.sans }]}>
-                  Agenda
-                </Text>
                 <Text style={[styles.sectionTitle, { color: tokens.colors.textPrimary, fontFamily: tokens.typography.sans }]}>
                   Event schedule
                 </Text>
               </View>
 
-              <View style={styles.cardStack}>
+              <View style={styles.agendaStack}>
                 {agendaDayGroups.map((group) => {
                   const expanded = expandedAgendaDays.includes(group.key);
                   const visibleItems = expanded ? group.items : group.items.slice(0, 3);
@@ -580,7 +673,7 @@ export function MobileEventDetailScreen({
                     <View
                       key={group.key}
                       style={[
-                        styles.infoCard,
+                        styles.agendaPanel,
                         {
                           backgroundColor: tokens.colors.surface,
                           borderColor: tokens.colors.border,
@@ -631,6 +724,45 @@ export function MobileEventDetailScreen({
                                   </Text>
                                 ) : null}
                               </View>
+                              {onToggleAgendaSave ? (
+                                <Pressable
+                                  accessibilityLabel={
+                                    agendaItem.isSaved
+                                      ? 'Remove saved session'
+                                      : 'Save session'
+                                  }
+                                  disabled={pendingAgendaSaveIds?.has(agendaItem.id)}
+                                  onPress={() =>
+                                    onToggleAgendaSave(agendaItem.id, !agendaItem.isSaved)
+                                  }
+                                  style={({ pressed }) => [
+                                    styles.agendaSaveButton,
+                                    {
+                                      backgroundColor: agendaItem.isSaved
+                                        ? tokens.colors.accentSoft
+                                        : pressed
+                                          ? tokens.colors.surfaceMuted
+                                          : 'transparent',
+                                      borderColor: agendaItem.isSaved
+                                        ? tokens.colors.accent
+                                        : tokens.colors.border,
+                                      opacity: pendingAgendaSaveIds?.has(agendaItem.id)
+                                        ? 0.45
+                                        : 1,
+                                    },
+                                  ]}
+                                >
+                                  <FontAwesome
+                                    name={agendaItem.isSaved ? 'bookmark' : 'bookmark-o'}
+                                    size={12}
+                                    color={
+                                      agendaItem.isSaved
+                                        ? tokens.colors.accent
+                                        : tokens.colors.textSecondary
+                                    }
+                                  />
+                                </Pressable>
+                              ) : null}
                             </View>
                           );
                         })}
@@ -658,13 +790,42 @@ export function MobileEventDetailScreen({
             <View style={{ flex: 1 }}>
               <KureButton onPress={onPrimaryAction}>{primaryLabel}</KureButton>
             </View>
-            {canOpenEventPage ? (
-              <View style={{ flex: 1 }}>
-                <KureButton variant="secondary" onPress={onOpenEventPage}>
-                  Official site
-                </KureButton>
-              </View>
-            ) : null}
+            <Pressable
+              accessibilityLabel={attendanceCta.accessibilityLabel}
+              disabled={isAttendancePending}
+              onPress={onToggleAttendance}
+              style={({ pressed }) => [
+                styles.attendanceButton,
+                {
+                  backgroundColor: attendanceCta.active
+                    ? tokens.colors.accentSoft
+                    : pressed
+                      ? tokens.colors.surfaceMuted
+                      : tokens.colors.surface,
+                  borderColor: attendanceCta.active
+                    ? tokens.colors.accent
+                    : tokens.colors.borderStrong,
+                  opacity: isAttendancePending ? 0.45 : 1,
+                },
+              ]}
+            >
+              <FontAwesome
+                name={attendanceCta.icon}
+                size={13}
+                color={attendanceCta.active ? tokens.colors.accent : tokens.colors.textSecondary}
+              />
+              <Text
+                style={[
+                  styles.attendanceLabel,
+                  {
+                    color: attendanceCta.active ? tokens.colors.accent : tokens.colors.textPrimary,
+                    fontFamily: tokens.typography.sans,
+                  },
+                ]}
+              >
+                {attendanceCta.label}
+              </Text>
+            </Pressable>
           </View>
         </View>
       </View>
@@ -681,40 +842,44 @@ const styles = StyleSheet.create({
   },
   header: {
     borderBottomWidth: StyleSheet.hairlineWidth,
-    paddingBottom: 14,
-    paddingHorizontal: 16,
+    paddingBottom: 24,
+    paddingHorizontal: 14,
   },
   headerRow: {
+    gap: 16,
+  },
+  headerControls: {
     flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 12,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  headerBackButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   headerCopy: {
-    flex: 1,
-    gap: 4,
-  },
-  headerEyebrow: {
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 0.2,
+    gap: 12,
+    minHeight: 84,
   },
   headerTitle: {
-    fontSize: 28,
-    lineHeight: 30,
-    fontWeight: '800',
-    letterSpacing: -0.9,
+    fontSize: 22,
+    lineHeight: 26,
+    fontWeight: '700',
+    letterSpacing: 0,
   },
   metaCluster: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 6,
-    marginTop: 6,
   },
   metaBadge: {
-    borderRadius: 999,
+    borderRadius: 3,
     borderWidth: 1,
     paddingHorizontal: 8,
-    paddingVertical: 3,
+    paddingVertical: 2,
   },
   metaBadgeText: {
     fontSize: 10,
@@ -725,12 +890,12 @@ const styles = StyleSheet.create({
   headerActions: {
     position: 'relative',
     flexDirection: 'row',
-    gap: 8,
+    gap: 6,
   },
   iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 999,
+    width: 32,
+    height: 32,
+    borderRadius: 6,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -743,42 +908,42 @@ const styles = StyleSheet.create({
   },
   menu: {
     position: 'absolute',
-    top: 48,
+    top: 40,
     right: 0,
     width: 188,
-    borderRadius: 18,
+    borderRadius: 6,
     borderWidth: 1,
-    paddingVertical: 6,
+    paddingVertical: 4,
     zIndex: 3,
   },
   menuItem: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
   },
   menuLabel: {
-    fontSize: 14,
+    fontSize: 13,
     fontWeight: '600',
   },
   scroll: {
     flex: 1,
   },
   scrollContent: {
-    gap: 20,
-    paddingHorizontal: 16,
-    paddingTop: 18,
-    paddingBottom: 16,
+    gap: 30,
+    paddingHorizontal: 14,
+    paddingTop: 26,
+    paddingBottom: 36,
   },
-  metaSheet: {
-    borderRadius: 20,
+  factPanel: {
+    borderRadius: 6,
     borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
   },
   iconMetaRowPressable: {
-    paddingHorizontal: 14,
-    paddingVertical: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 16,
   },
   iconMetaRow: {
     flexDirection: 'row',
@@ -791,17 +956,17 @@ const styles = StyleSheet.create({
   },
   metaRowText: {
     fontSize: 14,
-    lineHeight: 20,
+    lineHeight: 18,
     fontWeight: '600',
   },
   calendarStatusLabel: {
     fontSize: 12,
-    lineHeight: 18,
-    marginTop: 4,
+    lineHeight: 16,
+    marginTop: 2,
   },
   metaDivider: {
     height: StyleSheet.hairlineWidth,
-    marginHorizontal: 14,
+    marginHorizontal: 16,
   },
   organizerLabel: {
     fontSize: 11,
@@ -809,14 +974,14 @@ const styles = StyleSheet.create({
     marginBottom: 1,
   },
   hostLogo: {
-    width: 32,
-    height: 32,
-    borderRadius: 8,
+    width: 28,
+    height: 28,
+    borderRadius: 4,
   },
   hostFallback: {
-    width: 32,
-    height: 32,
-    borderRadius: 8,
+    width: 28,
+    height: 28,
+    borderRadius: 4,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -826,83 +991,135 @@ const styles = StyleSheet.create({
   },
   ctaBar: {
     borderTopWidth: StyleSheet.hairlineWidth,
-    paddingTop: 12,
-    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingHorizontal: 14,
   },
   ctaRow: {
     flexDirection: 'row',
     gap: 10,
   },
+  attendanceButton: {
+    minWidth: 118,
+    minHeight: 32,
+    borderRadius: 6,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+  },
+  attendanceLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
   section: {
-    gap: 12,
+    gap: 14,
   },
   sectionHeader: {
-    gap: 4,
-  },
-  sectionEyebrow: {
-    fontSize: 11,
-    fontWeight: '700',
-    letterSpacing: 1.1,
-    textTransform: 'uppercase',
+    gap: 2,
   },
   sectionTitle: {
-    fontSize: 20,
-    lineHeight: 24,
-    fontWeight: '800',
-    letterSpacing: -0.6,
+    fontSize: 18,
+    lineHeight: 23,
+    fontWeight: '700',
+    letterSpacing: 0,
   },
   sectionBody: {
-    fontSize: 15,
+    fontSize: 14,
     lineHeight: 22,
   },
   linkLabel: {
-    fontSize: 14,
+    fontSize: 13,
     fontWeight: '700',
   },
   tagWrap: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8,
+    columnGap: 6,
+    rowGap: 10,
   },
   tagBadge: {
-    minHeight: 30,
-    borderRadius: 999,
+    minHeight: 26,
+    borderRadius: 3,
     borderWidth: 1,
     justifyContent: 'center',
-    paddingHorizontal: 11,
+    paddingHorizontal: 9,
   },
   tagText: {
     fontSize: 12,
     fontWeight: '600',
   },
-  cardStack: {
-    gap: 12,
+  pulseGrid: {
+    flexDirection: 'row',
+    gap: 8,
   },
-  infoCard: {
-    borderRadius: 20,
+  pulseMetric: {
+    flex: 1,
+    minHeight: 96,
+    borderRadius: 6,
     borderWidth: StyleSheet.hairlineWidth,
     gap: 10,
-    padding: 14,
+    justifyContent: 'space-between',
+    padding: 16,
+  },
+  pulseLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  pulseValue: {
+    fontSize: 16,
+    lineHeight: 20,
+    fontWeight: '700',
+  },
+  pulseMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  pulseMeta: {
+    fontSize: 13,
+    lineHeight: 17,
+    fontWeight: '600',
+  },
+  listPanel: {
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  agendaStack: {
+    gap: 8,
+  },
+  agendaPanel: {
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
   },
   speakerRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 12,
+    gap: 10,
+  },
+  speakerListRow: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
   },
   speakerAvatar: {
-    width: 52,
-    height: 52,
-    borderRadius: 999,
+    width: 36,
+    height: 36,
+    borderRadius: 6,
   },
   speakerFallback: {
-    width: 52,
-    height: 52,
-    borderRadius: 999,
+    width: 36,
+    height: 36,
+    borderRadius: 6,
     alignItems: 'center',
     justifyContent: 'center',
   },
   speakerFallbackText: {
-    fontSize: 16,
+    fontSize: 13,
     fontWeight: '700',
   },
   speakerCopy: {
@@ -910,8 +1127,8 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   cardTitle: {
-    fontSize: 16,
-    lineHeight: 20,
+    fontSize: 14,
+    lineHeight: 18,
     fontWeight: '700',
   },
   cardMeta: {
@@ -923,6 +1140,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     gap: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
   },
   agendaHeaderCopy: {
     flex: 1,
@@ -933,18 +1152,28 @@ const styles = StyleSheet.create({
   },
   agendaItem: {
     flexDirection: 'row',
-    gap: 12,
+    gap: 10,
     borderTopWidth: StyleSheet.hairlineWidth,
-    paddingTop: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
   },
   agendaTime: {
-    width: 58,
+    width: 72,
     fontSize: 12,
     fontWeight: '700',
+    fontVariant: ['tabular-nums'],
   },
   agendaCopy: {
     flex: 1,
     gap: 4,
+  },
+  agendaSaveButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 4,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   agendaTitle: {
     fontSize: 14,

--- a/apps/mobile/src/components/event-detail/eventDetailUtils.test.ts
+++ b/apps/mobile/src/components/event-detail/eventDetailUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAttendanceCtaState } from './eventDetailUtils';
+
+const EVENT = {
+  startTime: '2026-05-24T16:00:00.000Z',
+  endTime: '2026-05-24T18:00:00.000Z',
+};
+
+describe('getAttendanceCtaState', () => {
+  it('uses RSVP controls until the event ends', () => {
+    const now = new Date('2026-05-24T17:00:00.000Z').getTime();
+
+    expect(getAttendanceCtaState(EVENT, undefined, now).label).toBe('Attend');
+    expect(
+      getAttendanceCtaState(EVENT, { isBookmarked: true, status: 'attending' }, now)
+        .label
+    ).toBe('Attending');
+  });
+
+  it('prompts any past-event visitor to confirm actual attendance', () => {
+    const now = new Date('2026-05-24T19:00:00.000Z').getTime();
+
+    expect(getAttendanceCtaState(EVENT, undefined, now).label).toBe('I attended');
+    expect(
+      getAttendanceCtaState(EVENT, { isBookmarked: true, status: 'attending' }, now)
+        .label
+    ).toBe('Confirm attendance');
+  });
+
+  it('opens review for an already attended event', () => {
+    const state = getAttendanceCtaState(
+      EVENT,
+      { isBookmarked: true, status: 'attended' },
+      new Date('2026-05-24T19:00:00.000Z').getTime()
+    );
+
+    expect(state.action).toBe('review');
+    expect(state.label).toBe('Attended');
+  });
+
+  it('falls back to start time when no end time is present', () => {
+    const state = getAttendanceCtaState(
+      { startTime: EVENT.startTime, endTime: null },
+      undefined,
+      new Date('2026-05-24T16:01:00.000Z').getTime()
+    );
+
+    expect(state.label).toBe('I attended');
+  });
+});

--- a/apps/mobile/src/components/event-detail/eventDetailUtils.ts
+++ b/apps/mobile/src/components/event-detail/eventDetailUtils.ts
@@ -2,6 +2,7 @@ import type {
   MobileEventDetail,
   MobileEventDetailAgendaItem,
   MobileEventDetailSpeaker,
+  MobileEventEngagement,
 } from '@kurecal/domain';
 
 const NON_MAPPABLE_LOCATIONS = new Set([
@@ -13,6 +14,68 @@ const NON_MAPPABLE_LOCATIONS = new Set([
 ]);
 
 export const SPEAKER_PREVIEW_COUNT = 4;
+
+export type AttendanceCtaState = {
+  action: 'toggle-rsvp' | 'confirm-attended' | 'review';
+  active: boolean;
+  accessibilityLabel: string;
+  icon: 'user-plus' | 'check-circle' | 'calendar-check-o';
+  label: string;
+};
+
+export function getAttendanceCtaState(
+  event: Pick<MobileEventDetail['event'], 'startTime' | 'endTime'>,
+  engagement?: MobileEventEngagement,
+  now = Date.now()
+): AttendanceCtaState {
+  const completionTime = new Date(event.endTime ?? event.startTime).getTime();
+  const hasEnded = !Number.isNaN(completionTime) && completionTime <= now;
+  const status = engagement?.status;
+
+  if (!hasEnded) {
+    return status === 'attending'
+      ? {
+          action: 'toggle-rsvp',
+          active: true,
+          accessibilityLabel: 'Remove RSVP',
+          icon: 'check-circle',
+          label: 'Attending',
+        }
+      : {
+          action: 'toggle-rsvp',
+          active: false,
+          accessibilityLabel: 'Mark attending',
+          icon: 'user-plus',
+          label: 'Attend',
+        };
+  }
+
+  if (status === 'attended') {
+    return {
+      action: 'review',
+      active: true,
+      accessibilityLabel: 'Review attended event',
+      icon: 'check-circle',
+      label: 'Attended',
+    };
+  }
+
+  return status === 'attending'
+    ? {
+        action: 'confirm-attended',
+        active: false,
+        accessibilityLabel: 'Confirm attendance',
+        icon: 'calendar-check-o',
+        label: 'Confirm attendance',
+      }
+    : {
+        action: 'confirm-attended',
+        active: false,
+        accessibilityLabel: 'Mark event attended',
+        icon: 'calendar-check-o',
+        label: 'I attended',
+      };
+}
 
 export type AgendaDayGroup = {
   key: string;

--- a/apps/mobile/src/lib/mobileApi.test.ts
+++ b/apps/mobile/src/lib/mobileApi.test.ts
@@ -31,6 +31,7 @@ import {
   loadMobileCommunityPost,
   loadMobileDiscoverFeed,
   loadMobileEventDetail,
+  loadMobileEventNetworkingFeedback,
   loadMobileFollowStatus,
   loadMobileProfileState,
   loadMobilePublicProfile,
@@ -46,7 +47,9 @@ import {
   syncMobileGoogleCalendarEvent,
   unfollowMobileUser,
   unsyncMobileGoogleCalendarEvent,
+  updateMobileEventAgendaSave,
   updateMobileEventEngagement,
+  updateMobileEventNetworkingFeedback,
   updateMobileProfile,
 } from './mobileApi';
 
@@ -207,6 +210,94 @@ describe('mobile api helpers', () => {
 
     await expect(loadMobileEventDetail('missing-event')).rejects.toThrow(
       'Event not found'
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it('saves agenda sessions through the event agenda save endpoint', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            eventId: 'event-1',
+            agendaItemId: 'agenda-1',
+            isSaved: true,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const result = await updateMobileEventAgendaSave(
+      'event-1',
+      'agenda-1',
+      true
+    );
+
+    expect(result.isSaved).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://mobile.kurecal.test/api/mobile/events/event-1/agenda/agenda-1/save',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it('loads and submits an event review rating with optional connections', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              eventId: 'event-1',
+              actualValueRating: null,
+              connectionsMade: null,
+              linkedinRequestsSent: null,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              eventId: 'event-1',
+              actualValueRating: 5,
+              connectionsMade: 2,
+              linkedinRequestsSent: null,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+
+    const initial = await loadMobileEventNetworkingFeedback('event-1');
+    const submitted = await updateMobileEventNetworkingFeedback('event-1', {
+      actualValueRating: 5,
+      connectionsMade: 2,
+    });
+
+    expect(initial.actualValueRating).toBeNull();
+    expect(submitted.actualValueRating).toBe(5);
+    expect(fetchSpy.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({
+          actualValueRating: 5,
+          connectionsMade: 2,
+        }),
+      })
     );
 
     fetchSpy.mockRestore();

--- a/apps/mobile/src/lib/mobileApi.ts
+++ b/apps/mobile/src/lib/mobileApi.ts
@@ -16,6 +16,7 @@ import {
   mobileDashboardSummarySchema,
   mobileDiscoverFeedRequestSchema,
   mobileDiscoverFeedSchema,
+  mobileEventAgendaSaveSchema,
   mobileEventDetailSchema,
   mobileEventNetworkingFeedbackSchema,
   mobileEventNetworkingFeedbackUpdateSchema,
@@ -52,6 +53,7 @@ import {
   type MobileDiscoverFeed,
   type MobileDiscoverFeedRequest,
   type MobileEventDetail,
+  type MobileEventAgendaSave,
   type MobileEventNetworkingFeedback,
   type MobileEventNetworkingFeedbackUpdate,
   type MobileEventEngagement,
@@ -476,6 +478,27 @@ export async function updateMobileEventEngagement(
     {
       method: 'PATCH',
       body: JSON.stringify(payload),
+    }
+  );
+}
+
+export async function updateMobileEventAgendaSave(
+  eventId: string,
+  agendaItemId: string,
+  isSaved: boolean
+): Promise<MobileEventAgendaSave> {
+  const trimmedEventId = eventId.trim();
+  const trimmedAgendaItemId = agendaItemId.trim();
+
+  if (!trimmedEventId || !trimmedAgendaItemId) {
+    throw new Error('Event id and agenda item id are required');
+  }
+
+  return fetchMobileContract(
+    `/api/mobile/events/${encodeURIComponent(trimmedEventId)}/agenda/${encodeURIComponent(trimmedAgendaItemId)}/save`,
+    mobileEventAgendaSaveSchema,
+    {
+      method: isSaved ? 'POST' : 'DELETE',
     }
   );
 }

--- a/packages/domain/src/mobile.test.ts
+++ b/packages/domain/src/mobile.test.ts
@@ -527,14 +527,30 @@ describe('mobile domain contracts', () => {
           startTime: '2026-04-20T18:00:00.000Z',
           endTime: '2026-04-20T18:30:00.000Z',
           title: 'Opening keynote',
+          topics: ['Expo'],
+          isSaved: true,
           speakers: [],
         },
       ],
+      networkingPulse: {
+        state: 'active',
+        trendingTopic: {
+          label: 'Expo',
+          activityLabel: 'Highly active',
+        },
+        mostSavedSession: {
+          agendaItemId: 'agenda-1',
+          title: 'Opening keynote',
+          saveCount: 12,
+        },
+      },
     });
 
     expect(parsed.host?.name).toBe('KureCal');
     expect(parsed.speakerLineup?.[0]?.name).toBe('Ada Lovelace');
     expect(parsed.agenda?.[0]?.title).toBe('Opening keynote');
+    expect(parsed.agenda?.[0]?.isSaved).toBe(true);
+    expect(parsed.networkingPulse?.trendingTopic?.label).toBe('Expo');
   });
 
   it('parses saved feeds and profile state payloads for phase 3 surfaces', () => {
@@ -645,17 +661,23 @@ describe('mobile domain contracts', () => {
   it('parses mobile networking feedback payloads', () => {
     const parsed = mobileEventNetworkingFeedbackSchema.parse({
       eventId: 'event-1',
+      actualValueRating: 4,
       connectionsMade: 2,
       linkedinRequestsSent: 4,
     });
 
+    expect(parsed.actualValueRating).toBe(4);
     expect(parsed.connectionsMade).toBe(2);
     expect(parsed.linkedinRequestsSent).toBe(4);
   });
 
-  it('requires at least one field when updating mobile networking feedback', () => {
+  it('accepts a review rating and requires at least one field when updating mobile feedback', () => {
+    expect(
+      mobileEventNetworkingFeedbackUpdateSchema.parse({ actualValueRating: 5 })
+        .actualValueRating
+    ).toBe(5);
     expect(() => mobileEventNetworkingFeedbackUpdateSchema.parse({})).toThrow(
-      'At least one networking field must be provided.'
+      'At least one feedback field must be provided.'
     );
   });
 });

--- a/packages/domain/src/mobile.ts
+++ b/packages/domain/src/mobile.ts
@@ -78,6 +78,12 @@ export const mobileEventEngagementUpdateSchema = z
     }
   );
 
+export const mobileEventAgendaSaveSchema = z.object({
+  eventId: z.string(),
+  agendaItemId: z.string(),
+  isSaved: z.boolean(),
+});
+
 export const mobileLinkedInOutreachLogSchema = z.object({
   eventId: z.string(),
   connectionsMade: z.number().int().nonnegative(),
@@ -86,21 +92,24 @@ export const mobileLinkedInOutreachLogSchema = z.object({
 
 export const mobileEventNetworkingFeedbackSchema = z.object({
   eventId: z.string(),
+  actualValueRating: z.number().int().min(1).max(5).nullable(),
   connectionsMade: z.number().int().nonnegative().nullable(),
   linkedinRequestsSent: z.number().int().nonnegative().nullable(),
 });
 
 export const mobileEventNetworkingFeedbackUpdateSchema = z
   .object({
+    actualValueRating: z.number().int().min(1).max(5).nullable().optional(),
     connectionsMade: z.number().int().nonnegative().nullable().optional(),
     linkedinRequestsSent: z.number().int().nonnegative().nullable().optional(),
   })
   .refine(
     (value) =>
+      Object.prototype.hasOwnProperty.call(value, 'actualValueRating') ||
       Object.prototype.hasOwnProperty.call(value, 'connectionsMade') ||
       Object.prototype.hasOwnProperty.call(value, 'linkedinRequestsSent'),
     {
-      message: 'At least one networking field must be provided.',
+      message: 'At least one feedback field must be provided.',
     }
   );
 
@@ -605,7 +614,26 @@ export const mobileEventDetailAgendaItemSchema = z.object({
   description: z.string().nullable().optional(),
   location: z.string().nullable().optional(),
   track: z.string().nullable().optional(),
+  topics: z.array(z.string()).optional(),
+  isSaved: z.boolean().optional(),
   speakers: z.array(mobileEventDetailSpeakerSchema),
+});
+
+export const mobileEventNetworkingPulseSchema = z.object({
+  state: z.enum(['empty', 'active']),
+  trendingTopic: z
+    .object({
+      label: z.string(),
+      activityLabel: z.string(),
+    })
+    .nullable(),
+  mostSavedSession: z
+    .object({
+      agendaItemId: z.string(),
+      title: z.string(),
+      saveCount: z.number().int().nonnegative(),
+    })
+    .nullable(),
 });
 
 export const mobileEventDetailSchema = z.object({
@@ -626,6 +654,7 @@ export const mobileEventDetailSchema = z.object({
   tags: z.array(z.string()).optional(),
   agenda: z.array(mobileEventDetailAgendaItemSchema).optional(),
   speakerLineup: z.array(mobileEventDetailSpeakerSchema).optional(),
+  networkingPulse: mobileEventNetworkingPulseSchema.optional(),
 });
 
 export const mobileOnboardingStatusSchema = z.object({
@@ -904,6 +933,12 @@ export type MobileEventDetailSpeaker = z.infer<
 >;
 export type MobileEventDetailAgendaItem = z.infer<
   typeof mobileEventDetailAgendaItemSchema
+>;
+export type MobileEventNetworkingPulse = z.infer<
+  typeof mobileEventNetworkingPulseSchema
+>;
+export type MobileEventAgendaSave = z.infer<
+  typeof mobileEventAgendaSaveSchema
 >;
 export type MobileEventDetail = z.infer<typeof mobileEventDetailSchema>;
 export type MobileOnboardingStatus = z.infer<typeof mobileOnboardingStatusSchema>;

--- a/src/app/api/mobile/events/[id]/agenda/[agendaItemId]/save/route.test.ts
+++ b/src/app/api/mobile/events/[id]/agenda/[agendaItemId]/save/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mobileEventAgendaSaveSchema } from '@kurecal/domain';
+
+import { DELETE, POST } from './route';
+
+const mocks = vi.hoisted(() => ({
+  getAuthenticatedRequestContext: vi.fn(),
+  setAgendaItemSaved: vi.fn(),
+}));
+
+vi.mock('@/utils/supabase/requestAuth', () => ({
+  getAuthenticatedRequestContext: (...args: unknown[]) =>
+    mocks.getAuthenticatedRequestContext(...args),
+}));
+
+vi.mock('@/services/eventAgendaSaveService', () => ({
+  EventAgendaSaveService: {
+    setAgendaItemSaved: (...args: unknown[]) =>
+      mocks.setAgendaItemSaved(...args),
+  },
+}));
+
+describe('/api/mobile/events/[id]/agenda/[agendaItemId]/save', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAuthenticatedRequestContext.mockResolvedValue({
+      authMethod: 'bearer',
+      supabase: {},
+      user: { id: 'user-1' },
+    });
+    mocks.setAgendaItemSaved.mockResolvedValue(undefined);
+  });
+
+  it('saves an agenda item for the authenticated user', async () => {
+    const response = await POST(
+      new Request(
+        'http://localhost/api/mobile/events/event-1/agenda/agenda-1/save',
+        { method: 'POST' }
+      ),
+      {
+        params: Promise.resolve({
+          id: 'event-1',
+          agendaItemId: 'agenda-1',
+        }),
+      }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.setAgendaItemSaved).toHaveBeenCalledWith(
+      {
+        eventId: 'event-1',
+        agendaItemId: 'agenda-1',
+        userId: 'user-1',
+        isSaved: true,
+      },
+      {}
+    );
+    expect(mobileEventAgendaSaveSchema.parse(payload.data).isSaved).toBe(true);
+  });
+
+  it('removes an agenda item save for the authenticated user', async () => {
+    const response = await DELETE(
+      new Request(
+        'http://localhost/api/mobile/events/event-1/agenda/agenda-1/save',
+        { method: 'DELETE' }
+      ),
+      {
+        params: Promise.resolve({
+          id: 'event-1',
+          agendaItemId: 'agenda-1',
+        }),
+      }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.setAgendaItemSaved).toHaveBeenCalledWith(
+      expect.objectContaining({ isSaved: false }),
+      {}
+    );
+    expect(mobileEventAgendaSaveSchema.parse(payload.data).isSaved).toBe(false);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mocks.getAuthenticatedRequestContext.mockResolvedValueOnce(null);
+
+    const response = await POST(
+      new Request(
+        'http://localhost/api/mobile/events/event-1/agenda/agenda-1/save',
+        { method: 'POST' }
+      ),
+      {
+        params: Promise.resolve({
+          id: 'event-1',
+          agendaItemId: 'agenda-1',
+        }),
+      }
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/mobile/events/[id]/agenda/[agendaItemId]/save/route.ts
+++ b/src/app/api/mobile/events/[id]/agenda/[agendaItemId]/save/route.ts
@@ -1,0 +1,70 @@
+import { mobileEventAgendaSaveSchema } from '@kurecal/domain';
+import { NextResponse } from 'next/server';
+
+import { EventAgendaSaveService } from '@/services/eventAgendaSaveService';
+import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
+
+interface RouteContext {
+  params: Promise<{ id: string; agendaItemId: string }>;
+}
+
+async function setSaved(request: Request, context: RouteContext, isSaved: boolean) {
+  const authContext = await getAuthenticatedRequestContext(request as never);
+  if (!authContext) {
+    return NextResponse.json(
+      { success: false, error: 'Authentication required' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const { id, agendaItemId } = await context.params;
+    const eventId = decodeURIComponent(id ?? '').trim();
+    const decodedAgendaItemId = decodeURIComponent(agendaItemId ?? '').trim();
+
+    if (!eventId || !decodedAgendaItemId) {
+      return NextResponse.json(
+        { success: false, error: 'Event id and agenda item id are required' },
+        { status: 400 }
+      );
+    }
+
+    await EventAgendaSaveService.setAgendaItemSaved(
+      {
+        eventId,
+        agendaItemId: decodedAgendaItemId,
+        userId: authContext.user.id,
+        isSaved,
+      },
+      authContext.supabase
+    );
+
+    return NextResponse.json({
+      success: true,
+      data: mobileEventAgendaSaveSchema.parse({
+        eventId,
+        agendaItemId: decodedAgendaItemId,
+        isSaved,
+      }),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Failed to update agenda session save';
+    const status = message.toLowerCase().includes('not found') ? 404 : 500;
+
+    return NextResponse.json(
+      { success: false, error: message },
+      { status }
+    );
+  }
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  return setSaved(request, context, true);
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  return setSaved(request, context, false);
+}

--- a/src/app/api/mobile/events/[id]/engagement/route.test.ts
+++ b/src/app/api/mobile/events/[id]/engagement/route.test.ts
@@ -93,4 +93,56 @@ describe('/api/mobile/events/[id]/engagement', () => {
 
     expect(response.status).toBe(401);
   });
+
+  it('records and removes confirmed attendance through the existing endpoint', async () => {
+    mocks.isEventTracked
+      .mockResolvedValueOnce({
+        isTracked: true,
+        isBookmarked: true,
+        status: 'attended',
+      })
+      .mockResolvedValueOnce({
+        isTracked: true,
+        isBookmarked: true,
+        status: null,
+      });
+
+    const attendedResponse = await PATCH(
+      new Request('http://localhost/api/mobile/events/event-1/engagement', {
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'attended' }),
+      }),
+      { params: Promise.resolve({ id: 'event-1' }) }
+    );
+    const clearedResponse = await PATCH(
+      new Request('http://localhost/api/mobile/events/event-1/engagement', {
+        method: 'PATCH',
+        body: JSON.stringify({ status: null }),
+      }),
+      { params: Promise.resolve({ id: 'event-1' }) }
+    );
+
+    expect(mocks.setAttendanceStatus).toHaveBeenNthCalledWith(
+      1,
+      'user-1',
+      'event-1',
+      'attended',
+      undefined,
+      {}
+    );
+    expect(mocks.setAttendanceStatus).toHaveBeenNthCalledWith(
+      2,
+      'user-1',
+      'event-1',
+      null,
+      undefined,
+      {}
+    );
+    expect(
+      mobileEventEngagementSchema.parse((await attendedResponse.json()).data).status
+    ).toBe('attended');
+    expect(
+      mobileEventEngagementSchema.parse((await clearedResponse.json()).data).status
+    ).toBeNull();
+  });
 });

--- a/src/app/api/mobile/events/[id]/feedback/route.test.ts
+++ b/src/app/api/mobile/events/[id]/feedback/route.test.ts
@@ -59,6 +59,7 @@ describe('/api/mobile/events/[id]/feedback', () => {
   it('returns the merged networking feedback snapshot', async () => {
     mocks.getFeedbackForEvent.mockResolvedValue({
       id: 'feedback-1',
+      actualValueRating: 4,
       connectionsMade: 2,
     });
     mocks.getSummaryForEvent.mockResolvedValue({
@@ -77,6 +78,7 @@ describe('/api/mobile/events/[id]/feedback', () => {
     expect(response.status).toBe(200);
     expect(mobileEventNetworkingFeedbackSchema.parse(payload.data)).toEqual({
       eventId: 'event-1',
+      actualValueRating: 4,
       connectionsMade: 2,
       linkedinRequestsSent: 4,
     });
@@ -85,6 +87,7 @@ describe('/api/mobile/events/[id]/feedback', () => {
   it('updates both confirmed connections and linkedin requests', async () => {
     mocks.getFeedbackForEvent.mockResolvedValue({
       id: 'feedback-1',
+      actualValueRating: null,
       connectionsMade: 1,
     });
     mocks.getSummaryForEvent.mockResolvedValue({
@@ -111,7 +114,7 @@ describe('/api/mobile/events/[id]/feedback', () => {
     expect(response.status).toBe(200);
     expect(mocks.updateFeedback).toHaveBeenCalledWith(
       'feedback-1',
-      { connectionsMade: 2 },
+      { actualValueRating: null, connectionsMade: 2 },
       {}
     );
     expect(mocks.setLinkedInRequestsSent).toHaveBeenCalledWith(
@@ -150,10 +153,43 @@ describe('/api/mobile/events/[id]/feedback', () => {
       expect.objectContaining({
         eventId: 'event-1',
         userId: 'user-1',
+        actualValueRating: null,
         connectionsMade: 1,
         predictedScore: 83,
       }),
       {}
     );
+  });
+
+  it('creates a first quick review with a rating and optional connections', async () => {
+    mocks.getEventById.mockResolvedValue({
+      id: 'event-1',
+      careerImpact: { overall: 83 },
+    });
+
+    const response = await PATCH(
+      new Request('http://localhost/api/mobile/events/event-1/feedback', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          actualValueRating: 5,
+          connectionsMade: 2,
+        }),
+      }),
+      {
+        params: Promise.resolve({ id: 'event-1' }),
+      }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.submitFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actualValueRating: 5,
+        connectionsMade: 2,
+      }),
+      {}
+    );
+    expect(mobileEventNetworkingFeedbackSchema.parse(payload.data).actualValueRating).toBe(5);
   });
 });

--- a/src/app/api/mobile/events/[id]/feedback/route.ts
+++ b/src/app/api/mobile/events/[id]/feedback/route.ts
@@ -78,6 +78,7 @@ export async function GET(request: Request, context: RouteContext) {
       success: true,
       data: mobileEventNetworkingFeedbackSchema.parse({
         eventId,
+        actualValueRating: feedback?.actualValueRating ?? null,
         connectionsMade: feedback?.connectionsMade ?? null,
         linkedinRequestsSent: networkingSummary?.linkedinRequestsSent ?? null,
       }),
@@ -131,41 +132,54 @@ export async function PATCH(request: Request, context: RouteContext) {
       ),
     ]);
 
+    let nextActualValueRating = existingFeedback?.actualValueRating ?? null;
     let nextConnectionsMade = existingFeedback?.connectionsMade ?? null;
     let nextLinkedInRequestsSent =
       existingNetworkingSummary?.linkedinRequestsSent ?? null;
 
+    if (Object.prototype.hasOwnProperty.call(payload, 'actualValueRating')) {
+      nextActualValueRating = payload.actualValueRating ?? null;
+    }
+
     if (Object.prototype.hasOwnProperty.call(payload, 'connectionsMade')) {
       nextConnectionsMade = payload.connectionsMade ?? null;
+    }
 
-      if (existingFeedback) {
-        await EventFeedbackService.updateFeedback(
-          existingFeedback.id,
-          {
-            connectionsMade: nextConnectionsMade,
-          },
-          authContext.supabase
-        );
-      } else if (nextConnectionsMade != null) {
-        const event = await EventService.getEventById(
+    const isUpdatingFeedback =
+      Object.prototype.hasOwnProperty.call(payload, 'actualValueRating') ||
+      Object.prototype.hasOwnProperty.call(payload, 'connectionsMade');
+
+    if (isUpdatingFeedback && existingFeedback) {
+      await EventFeedbackService.updateFeedback(
+        existingFeedback.id,
+        {
+          actualValueRating: nextActualValueRating,
+          connectionsMade: nextConnectionsMade,
+        },
+        authContext.supabase
+      );
+    } else if (
+      isUpdatingFeedback &&
+      (nextActualValueRating != null || nextConnectionsMade != null)
+    ) {
+      const event = await EventService.getEventById(
+        eventId,
+        authContext.supabase
+      );
+      await EventFeedbackService.submitFeedback(
+        {
           eventId,
-          authContext.supabase
-        );
-        await EventFeedbackService.submitFeedback(
-          {
-            eventId,
-            userId: authContext.user.id,
-            actualValueRating: null,
-            careerBenefit: null,
-            connectionsMade: nextConnectionsMade,
-            skillsGained: null,
-            wouldRecommend: null,
-            feedbackText: null,
-            predictedScore: getPredictedScore(getEventOverallScore(event)),
-          },
-          authContext.supabase
-        );
-      }
+          userId: authContext.user.id,
+          actualValueRating: nextActualValueRating,
+          careerBenefit: null,
+          connectionsMade: nextConnectionsMade,
+          skillsGained: null,
+          wouldRecommend: null,
+          feedbackText: null,
+          predictedScore: getPredictedScore(getEventOverallScore(event)),
+        },
+        authContext.supabase
+      );
     }
 
     if (Object.prototype.hasOwnProperty.call(payload, 'linkedinRequestsSent')) {
@@ -191,6 +205,7 @@ export async function PATCH(request: Request, context: RouteContext) {
       success: true,
       data: mobileEventNetworkingFeedbackSchema.parse({
         eventId,
+        actualValueRating: nextActualValueRating,
         connectionsMade: nextConnectionsMade,
         linkedinRequestsSent: nextLinkedInRequestsSent,
       }),

--- a/src/app/api/mobile/events/[id]/route.test.ts
+++ b/src/app/api/mobile/events/[id]/route.test.ts
@@ -8,7 +8,10 @@ const mocks = vi.hoisted(() => ({
   getAuthenticatedRequestContext: vi.fn(),
   getEventById: vi.fn(),
   getEventWithAgenda: vi.fn(),
+  getSavedAgendaItemIds: vi.fn(),
+  buildNetworkingPulse: vi.fn(),
   loadEngagementMap: vi.fn(),
+  createAdminClient: vi.fn(),
 }));
 
 vi.mock('@/utils/supabase/requestAuth', () => ({
@@ -24,8 +27,21 @@ vi.mock('@/services/eventServices', () => ({
   },
 }));
 
+vi.mock('@/services/eventAgendaSaveService', () => ({
+  EventAgendaSaveService: {
+    getSavedAgendaItemIds: (...args: unknown[]) =>
+      mocks.getSavedAgendaItemIds(...args),
+    buildNetworkingPulse: (...args: unknown[]) =>
+      mocks.buildNetworkingPulse(...args),
+  },
+}));
+
 vi.mock('@/app/api/mobile/engagement', () => ({
   loadEngagementMap: (...args: unknown[]) => mocks.loadEngagementMap(...args),
+}));
+
+vi.mock('@/utils/supabase/server', () => ({
+  createAdminClient: (...args: unknown[]) => mocks.createAdminClient(...args),
 }));
 
 const eventDetail = {
@@ -103,6 +119,7 @@ describe('GET /api/mobile/events/[id]', () => {
     });
     mocks.getEventWithAgenda.mockResolvedValue(eventDetail);
     mocks.getEventById.mockResolvedValue(eventDetail);
+    mocks.createAdminClient.mockResolvedValue({ admin: true });
     mocks.loadEngagementMap.mockResolvedValue(
       new Map([
         [
@@ -114,6 +131,19 @@ describe('GET /api/mobile/events/[id]', () => {
         ],
       ])
     );
+    mocks.getSavedAgendaItemIds.mockResolvedValue(new Set(['agenda-1']));
+    mocks.buildNetworkingPulse.mockResolvedValue({
+      state: 'active',
+      trendingTopic: {
+        label: 'Fabric',
+        activityLabel: 'Highly active',
+      },
+      mostSavedSession: {
+        agendaItemId: 'agenda-1',
+        title: 'Opening keynote',
+        saveCount: 4,
+      },
+    });
   });
 
   it('returns a typed event detail payload with agenda and speakers', async () => {
@@ -134,7 +164,62 @@ describe('GET /api/mobile/events/[id]', () => {
     expect(parsed.host?.name).toBe('KureCal');
     expect(parsed.event.engagement?.status).toBe('attending');
     expect(parsed.agenda?.[0]?.title).toBe('Opening keynote');
+    expect(parsed.agenda?.[0]?.isSaved).toBe(true);
     expect(parsed.speakerLineup?.[0]?.name).toBe('Ada Lovelace');
+    expect(parsed.networkingPulse?.mostSavedSession?.saveCount).toBe(4);
+  });
+
+  it('returns an empty networking pulse when aggregate signal is below threshold', async () => {
+    mocks.getSavedAgendaItemIds.mockResolvedValueOnce(new Set());
+    mocks.buildNetworkingPulse.mockResolvedValueOnce({
+      state: 'empty',
+      trendingTopic: null,
+      mostSavedSession: null,
+    });
+
+    const response = await GET(
+      new Request(`http://localhost/api/mobile/events/${eventDetail.id}`, {
+        headers: { Authorization: 'Bearer mobile-token' },
+      }),
+      {
+        params: Promise.resolve({ id: eventDetail.id }),
+      }
+    );
+    const payload = await response.json();
+    const parsed = mobileEventDetailSchema.parse(payload.data);
+
+    expect(response.status).toBe(200);
+    expect(parsed.networkingPulse?.state).toBe('empty');
+    expect(parsed.networkingPulse?.mostSavedSession).toBeNull();
+  });
+
+  it('keeps loading event detail when optional engagement and pulse data is unavailable', async () => {
+    mocks.loadEngagementMap.mockRejectedValueOnce({
+      message: 'user_events query failed',
+    });
+    mocks.getSavedAgendaItemIds.mockRejectedValueOnce({
+      message: 'relation "user_event_agenda_saves" does not exist',
+    });
+    mocks.buildNetworkingPulse.mockRejectedValueOnce({
+      message: 'user_event_agenda_saves aggregate query failed',
+    });
+
+    const response = await GET(
+      new Request(`http://localhost/api/mobile/events/${eventDetail.id}`, {
+        headers: { Authorization: 'Bearer mobile-token' },
+      }),
+      {
+        params: Promise.resolve({ id: eventDetail.id }),
+      }
+    );
+    const payload = await response.json();
+    const parsed = mobileEventDetailSchema.parse(payload.data);
+
+    expect(response.status).toBe(200);
+    expect(parsed.event.title).toBe('Expo Ship Week');
+    expect(parsed.event.engagement).toBeUndefined();
+    expect(parsed.agenda?.[0]?.isSaved).toBe(false);
+    expect(parsed.networkingPulse?.state).toBe('empty');
   });
 
   it('falls back to base event detail when agenda hydration fails', async () => {

--- a/src/app/api/mobile/events/[id]/route.ts
+++ b/src/app/api/mobile/events/[id]/route.ts
@@ -2,8 +2,33 @@ import { NextResponse } from 'next/server';
 
 import { loadEngagementMap } from '@/app/api/mobile/engagement';
 import { toMobileEventDetail } from '@/app/api/mobile/serializers';
+import { EventAgendaSaveService } from '@/services/eventAgendaSaveService';
 import { EventService } from '@/services/eventServices';
 import { getAuthenticatedRequestContext } from '@/utils/supabase/requestAuth';
+import { createAdminClient } from '@/utils/supabase/server';
+
+const EMPTY_NETWORKING_PULSE = {
+  state: 'empty' as const,
+  trendingTopic: null,
+  mostSavedSession: null,
+};
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message?: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message;
+  }
+
+  return String(error || 'Unknown error');
+}
 
 async function loadMobileEventDetailSource(
   id: string,
@@ -14,7 +39,7 @@ async function loadMobileEventDetailSource(
   try {
     return await EventService.getEventWithAgenda(id, supabase);
   } catch (error) {
-    const message = error instanceof Error ? error.message : '';
+    const message = getErrorMessage(error);
 
     if (message.toLowerCase().includes('not found')) {
       throw error;
@@ -44,19 +69,58 @@ export async function GET(
 
     const { id } = await params;
     const event = await loadMobileEventDetailSource(id, authContext.supabase);
-    const engagementMap = await loadEngagementMap(
-      authContext.supabase,
-      authContext.user.id,
-      [id]
-    );
+    const networkingPulsePromise = createAdminClient()
+      .then((adminClient) =>
+        EventAgendaSaveService.buildNetworkingPulse(
+          {
+            eventId: id,
+            agenda: event.agenda ?? [],
+          },
+          adminClient
+        )
+      )
+      .catch((error) => {
+        console.warn('[mobile/events] Networking pulse unavailable', {
+          eventId: id,
+          message: getErrorMessage(error),
+        });
+        return EMPTY_NETWORKING_PULSE;
+      });
+    const [engagementMap, savedAgendaItemIds, networkingPulse] = await Promise.all([
+      loadEngagementMap(authContext.supabase, authContext.user.id, [id]).catch(
+        (error) => {
+          console.warn('[mobile/events] Engagement state unavailable', {
+            eventId: id,
+            message: getErrorMessage(error),
+          });
+          return new Map();
+        }
+      ),
+      EventAgendaSaveService.getSavedAgendaItemIds(
+        {
+          eventId: id,
+          userId: authContext.user.id,
+        },
+        authContext.supabase
+      ).catch((error) => {
+        console.warn('[mobile/events] Agenda save state unavailable', {
+          eventId: id,
+          message: getErrorMessage(error),
+        });
+        return new Set<string>();
+      }),
+      networkingPulsePromise,
+    ]);
 
     return NextResponse.json({
       success: true,
-      data: toMobileEventDetail(event, engagementMap.get(id)),
+      data: toMobileEventDetail(event, engagementMap.get(id), {
+        savedAgendaItemIds,
+        networkingPulse,
+      }),
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Failed to load event detail';
+    const message = getErrorMessage(error) || 'Failed to load event detail';
     const status = message.toLowerCase().includes('not found') ? 404 : 500;
 
     return NextResponse.json(

--- a/src/app/api/mobile/serializers.ts
+++ b/src/app/api/mobile/serializers.ts
@@ -32,6 +32,7 @@ import {
   type MobileEventDetailAgendaItem,
   type MobileEventDetailSpeaker,
   type MobileEventEngagement,
+  type MobileEventNetworkingPulse,
   type MobileEventSummary,
   type MobileSurfaceHeader,
 } from '@kurecal/domain';
@@ -414,7 +415,10 @@ function toAgendaSpeakers(agendaItem: AgendaItem): MobileEventDetailSpeaker[] {
   return Array.from(deduped.values());
 }
 
-function toAgendaItem(agendaItem: AgendaItem): MobileEventDetailAgendaItem {
+function toAgendaItem(
+  agendaItem: AgendaItem,
+  savedAgendaItemIds?: Set<string>
+): MobileEventDetailAgendaItem {
   return {
     id: agendaItem.id,
     dayNumber:
@@ -427,6 +431,10 @@ function toAgendaItem(agendaItem: AgendaItem): MobileEventDetailAgendaItem {
     description: agendaItem.description?.trim() || null,
     location: agendaItem.location?.trim() || null,
     track: agendaItem.track?.trim() || null,
+    topics: (agendaItem.topics ?? [])
+      .map((topic) => topic.trim())
+      .filter(Boolean),
+    isSaved: savedAgendaItemIds?.has(agendaItem.id) ?? false,
     speakers: toAgendaSpeakers(agendaItem),
   };
 }
@@ -548,7 +556,11 @@ export function trackedRecordToEventCard(record: {
 
 export function toMobileEventDetail(
   event: Event,
-  engagement?: MobileEventEngagement | null
+  engagement?: MobileEventEngagement | null,
+  options: {
+    savedAgendaItemIds?: Set<string>;
+    networkingPulse?: MobileEventNetworkingPulse;
+  } = {}
 ): MobileEventDetail {
   const summary = toMobileEventSummary(event, engagement);
 
@@ -569,8 +581,11 @@ export function toMobileEventDetail(
           }
         : null,
     tags: summary.tags,
-    agenda: (event.agenda ?? []).map((agendaItem) => toAgendaItem(agendaItem)),
+    agenda: (event.agenda ?? []).map((agendaItem) =>
+      toAgendaItem(agendaItem, options.savedAgendaItemIds)
+    ),
     speakerLineup: collectSpeakerLineup(event),
+    networkingPulse: options.networkingPulse,
   });
 }
 

--- a/src/services/__tests__/publicProfileService.test.ts
+++ b/src/services/__tests__/publicProfileService.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PublicProfileService } from '../publicProfileService';
+import type { SupabaseClientType } from '@/types';
+
+function createEventQuery(data: unknown[]) {
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    in: vi.fn(() => query),
+    gte: vi.fn(() => query),
+    lt: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    then: (
+      onFulfilled?: (result: { data: unknown[]; error: null }) => unknown,
+      onRejected?: (reason: unknown) => unknown
+    ) => Promise.resolve({ data, error: null }).then(onFulfilled, onRejected),
+  };
+
+  return query;
+}
+
+type RecentEventReader = {
+  getRecentAttendingEvents: (input: {
+    readClient: SupabaseClientType;
+    userId: string;
+    viewerId: string | null;
+    isViewerOwner: boolean;
+    canViewAttendance: boolean;
+  }) => Promise<unknown[]>;
+};
+
+describe('PublicProfileService recent journey', () => {
+  it('excludes a stale attended activity after attendance is removed', async () => {
+    const stalePastEvent = {
+      id: 'event-1',
+      slug: 'data-saturday-chicago-2026',
+      title: 'Data Saturday Chicago 2026',
+      start_time: '2026-03-14T07:00:00.000Z',
+      end_time: null,
+      location: 'Palatine, USA',
+      user_events: [{
+        user_id: 'user-1',
+        activity_type: 'attended',
+        role: null,
+        status: null,
+      }],
+    };
+    const readClient = {
+      from: vi.fn()
+        .mockReturnValueOnce(createEventQuery([]))
+        .mockReturnValueOnce(createEventQuery([stalePastEvent])),
+    } as unknown as SupabaseClientType;
+
+    const events = await (PublicProfileService as unknown as RecentEventReader).getRecentAttendingEvents({
+      readClient,
+      userId: 'user-1',
+      viewerId: 'user-1',
+      isViewerOwner: false,
+      canViewAttendance: true,
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('retains speaking activity independently of removed attendance', async () => {
+    const speakingEvent = {
+      id: 'event-2',
+      slug: 'speaker-event',
+      title: 'Speaker Event',
+      start_time: '2026-03-14T07:00:00.000Z',
+      end_time: null,
+      location: null,
+      user_events: [{
+        user_id: 'user-1',
+        activity_type: 'speaking',
+        role: 'Speaker',
+        status: null,
+      }],
+    };
+    const readClient = {
+      from: vi.fn()
+        .mockReturnValueOnce(createEventQuery([]))
+        .mockReturnValueOnce(createEventQuery([speakingEvent])),
+    } as unknown as SupabaseClientType;
+
+    const events = await (PublicProfileService as unknown as RecentEventReader).getRecentAttendingEvents({
+      readClient,
+      userId: 'user-1',
+      viewerId: null,
+      isViewerOwner: false,
+      canViewAttendance: true,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ id: 'event-2', activityType: 'speaking' });
+  });
+});

--- a/src/services/__tests__/userEventService.test.ts
+++ b/src/services/__tests__/userEventService.test.ts
@@ -166,6 +166,77 @@ describe('UserEventService', () => {
     });
   });
 
+  describe('setAttendanceStatus', () => {
+    it('clears past attendance activity when attendance is removed', async () => {
+      mockSupabase.maybeSingle.mockResolvedValue({
+        data: { status: 'attended', is_bookmarked: false, activity_type: 'attended' },
+        error: null,
+      });
+
+      const result = await UserEventService.setAttendanceStatus(
+        'user1',
+        'event1',
+        null,
+        undefined,
+        mockSupabase as unknown as SupabaseClient
+      );
+
+      expect(mockSupabase.select).toHaveBeenCalledWith('status, is_bookmarked, activity_type');
+      expect(mockSupabase.update).toHaveBeenCalledWith({
+        status: null,
+        notes: null,
+        activity_type: null,
+      });
+      expect(result).toEqual({
+        previousStatus: 'attended',
+        newStatus: null,
+        autoBookmarked: false,
+      });
+    });
+
+    it('retains a cleared bookmarked event as saved activity only', async () => {
+      mockSupabase.maybeSingle.mockResolvedValue({
+        data: { status: 'attended', is_bookmarked: true, activity_type: 'attended' },
+        error: null,
+      });
+
+      await UserEventService.setAttendanceStatus(
+        'user1',
+        'event1',
+        null,
+        undefined,
+        mockSupabase as unknown as SupabaseClient
+      );
+
+      expect(mockSupabase.update).toHaveBeenCalledWith({
+        status: null,
+        notes: null,
+        activity_type: 'saved',
+      });
+    });
+
+    it('preserves a speaking activity marker when attendance is removed', async () => {
+      mockSupabase.maybeSingle.mockResolvedValue({
+        data: { status: 'attended', is_bookmarked: true, activity_type: 'speaking' },
+        error: null,
+      });
+
+      await UserEventService.setAttendanceStatus(
+        'user1',
+        'event1',
+        null,
+        undefined,
+        mockSupabase as unknown as SupabaseClient
+      );
+
+      expect(mockSupabase.update).toHaveBeenCalledWith({
+        status: null,
+        notes: null,
+        activity_type: 'speaking',
+      });
+    });
+  });
+
   describe('untrackEvent', () => {
     it('should untrack an event successfully', async () => {
       mockSupabase.rpc.mockResolvedValue({

--- a/src/services/eventAgendaSaveService.test.ts
+++ b/src/services/eventAgendaSaveService.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { EventAgendaSaveService } from './eventAgendaSaveService';
+
+function buildSupabaseWithSaves(agendaItemIds: string[]) {
+  const query = {
+    select: () => query,
+    eq: async () => ({
+      data: agendaItemIds.map((agenda_item_id) => ({ agenda_item_id })),
+      error: null,
+    }),
+  };
+
+  return {
+    from: () => query,
+  } as any;
+}
+
+describe('EventAgendaSaveService.buildNetworkingPulse', () => {
+  it('returns active pulse data from aggregate session saves', async () => {
+    const pulse = await EventAgendaSaveService.buildNetworkingPulse(
+      {
+        eventId: 'event-1',
+        agenda: [
+          {
+            id: 'agenda-1',
+            title: 'Advanced T-SQL Triage',
+            startTime: '2026-04-12T18:00:00.000Z',
+            endTime: '2026-04-12T18:45:00.000Z',
+            type: 'session',
+            topics: ['Microsoft Fabric'],
+          },
+        ],
+      },
+      buildSupabaseWithSaves(Array(12).fill('agenda-1'))
+    );
+
+    expect(pulse.state).toBe('active');
+    expect(pulse.trendingTopic?.label).toBe('Microsoft Fabric');
+    expect(pulse.trendingTopic?.activityLabel).toBe('Highly active');
+    expect(pulse.mostSavedSession?.saveCount).toBe(12);
+  });
+
+  it('returns empty pulse data below the privacy threshold', async () => {
+    const pulse = await EventAgendaSaveService.buildNetworkingPulse(
+      {
+        eventId: 'event-1',
+        agenda: [
+          {
+            id: 'agenda-1',
+            title: 'Small session',
+            startTime: '2026-04-12T18:00:00.000Z',
+            endTime: '2026-04-12T18:45:00.000Z',
+            type: 'session',
+            track: 'Data',
+          },
+        ],
+      },
+      buildSupabaseWithSaves(['agenda-1'])
+    );
+
+    expect(pulse).toEqual({
+      state: 'empty',
+      trendingTopic: null,
+      mostSavedSession: null,
+    });
+  });
+});

--- a/src/services/eventAgendaSaveService.ts
+++ b/src/services/eventAgendaSaveService.ts
@@ -1,0 +1,214 @@
+import type { MobileEventNetworkingPulse } from '@kurecal/domain';
+
+import type { AgendaItem, SupabaseClientType } from '@/types';
+
+const PULSE_PRIVACY_THRESHOLD = 2;
+
+type AgendaSaveRow = {
+  agenda_item_id: string;
+};
+
+function getUntypedClient(supabase: SupabaseClientType) {
+  return supabase as unknown as {
+    from: (table: string) => any;
+  };
+}
+
+function normalizeTopic(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+function buildActivityLabel(count: number) {
+  if (count >= 10) {
+    return 'Highly active';
+  }
+
+  if (count >= 5) {
+    return 'Growing fast';
+  }
+
+  return 'Emerging';
+}
+
+export class EventAgendaSaveService {
+  static async getSavedAgendaItemIds(
+    params: {
+      eventId: string;
+      userId: string;
+    },
+    supabase: SupabaseClientType
+  ): Promise<Set<string>> {
+    const { data, error } = await getUntypedClient(supabase)
+      .from('user_event_agenda_saves')
+      .select('agenda_item_id')
+      .eq('event_id', params.eventId)
+      .eq('user_id', params.userId);
+
+    if (error) {
+      console.error('[EventAgendaSaveService] Failed to load agenda saves', error);
+      throw error;
+    }
+
+    return new Set(
+      ((data as Array<{ agenda_item_id: string }> | null) ?? []).map(
+        (row) => row.agenda_item_id
+      )
+    );
+  }
+
+  static async setAgendaItemSaved(
+    params: {
+      eventId: string;
+      agendaItemId: string;
+      userId: string;
+      isSaved: boolean;
+    },
+    supabase: SupabaseClientType
+  ): Promise<void> {
+    const client = getUntypedClient(supabase);
+
+    const { data: agendaItem, error: agendaError } = await client
+      .from('event_agenda')
+      .select('id')
+      .eq('id', params.agendaItemId)
+      .eq('event_id', params.eventId)
+      .maybeSingle();
+
+    if (agendaError) {
+      console.error('[EventAgendaSaveService] Failed to verify agenda item', agendaError);
+      throw agendaError;
+    }
+
+    if (!agendaItem) {
+      throw new Error('Agenda item not found for this event');
+    }
+
+    if (params.isSaved) {
+      const { error } = await client
+        .from('user_event_agenda_saves')
+        .upsert(
+          {
+            user_id: params.userId,
+            event_id: params.eventId,
+            agenda_item_id: params.agendaItemId,
+          },
+          { onConflict: 'user_id,agenda_item_id' }
+        );
+
+      if (error) {
+        console.error('[EventAgendaSaveService] Failed to save agenda item', error);
+        throw error;
+      }
+
+      return;
+    }
+
+    const { error } = await client
+      .from('user_event_agenda_saves')
+      .delete()
+      .eq('user_id', params.userId)
+      .eq('event_id', params.eventId)
+      .eq('agenda_item_id', params.agendaItemId);
+
+    if (error) {
+      console.error('[EventAgendaSaveService] Failed to unsave agenda item', error);
+      throw error;
+    }
+  }
+
+  static async buildNetworkingPulse(
+    params: {
+      eventId: string;
+      agenda: AgendaItem[];
+    },
+    supabase: SupabaseClientType
+  ): Promise<MobileEventNetworkingPulse> {
+    const { data, error } = await getUntypedClient(supabase)
+      .from('user_event_agenda_saves')
+      .select('agenda_item_id')
+      .eq('event_id', params.eventId);
+
+    if (error) {
+      console.error('[EventAgendaSaveService] Failed to load pulse counts', error);
+      throw error;
+    }
+
+    const saveCounts = new Map<string, number>();
+    for (const row of (data as AgendaSaveRow[] | null) ?? []) {
+      saveCounts.set(
+        row.agenda_item_id,
+        (saveCounts.get(row.agenda_item_id) ?? 0) + 1
+      );
+    }
+    const counts = Array.from(saveCounts, ([agenda_item_id, save_count]) => ({
+      agenda_item_id,
+      save_count,
+    }));
+
+    if (counts.length === 0) {
+      return {
+        state: 'empty',
+        trendingTopic: null,
+        mostSavedSession: null,
+      };
+    }
+
+    const agendaById = new Map(params.agenda.map((item) => [item.id, item]));
+    const validCounts = counts.filter((row) => agendaById.has(row.agenda_item_id));
+    const sortedCounts = validCounts
+      .filter((row) => row.save_count >= PULSE_PRIVACY_THRESHOLD)
+      .sort((left, right) => right.save_count - left.save_count);
+    const topSessionCount = sortedCounts[0] ?? null;
+    const topicCounts = new Map<string, number>();
+
+    for (const row of validCounts) {
+      const agendaItem = agendaById.get(row.agenda_item_id);
+      if (!agendaItem) {
+        continue;
+      }
+
+      const labels =
+        agendaItem.topics && agendaItem.topics.length > 0
+          ? agendaItem.topics
+          : [agendaItem.track];
+
+      for (const label of labels) {
+        const normalized = normalizeTopic(label);
+        if (!normalized) {
+          continue;
+        }
+
+        topicCounts.set(
+          normalized,
+          (topicCounts.get(normalized) ?? 0) + row.save_count
+        );
+      }
+    }
+
+    const topTopic = Array.from(topicCounts.entries())
+      .filter((entry) => entry[1] >= PULSE_PRIVACY_THRESHOLD)
+      .sort((left, right) => right[1] - left[1])[0];
+    const topAgendaItem = topSessionCount
+      ? agendaById.get(topSessionCount.agenda_item_id)
+      : null;
+
+    return {
+      state: topSessionCount || topTopic ? 'active' : 'empty',
+      trendingTopic: topTopic
+        ? {
+            label: topTopic[0],
+            activityLabel: buildActivityLabel(topTopic[1]),
+          }
+        : null,
+      mostSavedSession:
+        topSessionCount && topAgendaItem
+          ? {
+              agendaItemId: topSessionCount.agenda_item_id,
+              title: topAgendaItem.title,
+              saveCount: topSessionCount.save_count,
+            }
+          : null,
+    };
+  }
+}

--- a/src/services/publicProfileService.ts
+++ b/src/services/publicProfileService.ts
@@ -44,6 +44,7 @@ interface EventRow {
     user_id: string;
     activity_type: PublicProfileEventActivityType | null;
     role: string | null;
+    status: 'attending' | 'attended' | 'cancelled' | null;
   }>;
 }
 
@@ -726,7 +727,7 @@ export class PublicProfileService {
     const upcomingPromise = readClient
       .from('events')
       .select(
-        'id, slug, title, start_time, end_time, location, user_events!inner(user_id, activity_type, role)'
+        'id, slug, title, start_time, end_time, location, user_events!inner(user_id, activity_type, role, status)'
       )
       .eq('user_events.user_id', userId)
       .in('user_events.activity_type', ['attending', 'speaking', 'saved'])
@@ -738,7 +739,7 @@ export class PublicProfileService {
     const pastPromise = readClient
       .from('events')
       .select(
-        'id, slug, title, start_time, end_time, location, user_events!inner(user_id, activity_type, role)'
+        'id, slug, title, start_time, end_time, location, user_events!inner(user_id, activity_type, role, status)'
       )
       .eq('user_events.user_id', userId)
       .in('user_events.activity_type', ['attended', 'speaking'])
@@ -762,7 +763,15 @@ export class PublicProfileService {
     const upcoming = (upcomingResult.data || []) as unknown as EventRow[];
     const past = (pastResult.data || []) as unknown as EventRow[];
 
-    const combined = [...upcoming, ...past].slice(0, limit);
+    const combined = [...upcoming, ...past]
+      .filter((event) => {
+        const link = event.user_events?.[0];
+        if (link?.activity_type === 'attending' || link?.activity_type === 'attended') {
+          return link.status === 'attending' || link.status === 'attended';
+        }
+        return true;
+      })
+      .slice(0, limit);
 
     const events: PublicProfileEvent[] = combined.map((event) => {
       const link = event.user_events?.[0];

--- a/src/services/userEventService.ts
+++ b/src/services/userEventService.ts
@@ -166,17 +166,26 @@ export class UserEventService {
                 // First, get the current status before clearing
                 const { data: existingRecord } = await supabaseClient
                     .from('user_events')
-                    .select('status')
+                    .select('status, is_bookmarked, activity_type')
                     .eq('user_id', userId)
                     .eq('event_id', eventId)
                     .maybeSingle();
 
                 const previousStatus = existingRecord?.status ?? null;
+                const clearedActivityType = existingRecord?.activity_type === 'speaking'
+                    ? 'speaking'
+                    : existingRecord?.is_bookmarked
+                        ? 'saved'
+                        : null;
 
-                // Update the record to set status to null
+                // Cleared attendance must not remain visible as attending/attended activity.
                 const { error: updateError } = await supabaseClient
                     .from('user_events')
-                    .update({ status: null, notes: notes ?? null })
+                    .update({
+                        status: null,
+                        notes: notes ?? null,
+                        activity_type: clearedActivityType
+                    })
                     .eq('user_id', userId)
                     .eq('event_id', eventId);
 

--- a/supabase/migrations/20260524000000_event_agenda_saves.sql
+++ b/supabase/migrations/20260524000000_event_agenda_saves.sql
@@ -1,0 +1,51 @@
+-- Session-level saves for event agenda items.
+-- Raw rows are user-owned; event detail surfaces only aggregate counts via RPC.
+
+create table if not exists public.user_event_agenda_saves (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  event_id uuid not null references public.events(id) on delete cascade,
+  agenda_item_id uuid not null references public.event_agenda(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (user_id, agenda_item_id)
+);
+
+create index if not exists user_event_agenda_saves_event_idx
+  on public.user_event_agenda_saves (event_id, agenda_item_id);
+
+create index if not exists user_event_agenda_saves_user_event_idx
+  on public.user_event_agenda_saves (user_id, event_id);
+
+alter table public.user_event_agenda_saves enable row level security;
+
+drop policy if exists "Users can read own agenda saves" on public.user_event_agenda_saves;
+create policy "Users can read own agenda saves"
+  on public.user_event_agenda_saves
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists "Users can create own agenda saves" on public.user_event_agenda_saves;
+create policy "Users can create own agenda saves"
+  on public.user_event_agenda_saves
+  for insert
+  to authenticated
+  with check (
+    auth.uid() = user_id
+    and exists (
+      select 1
+      from public.event_agenda ea
+      where ea.id = agenda_item_id
+        and ea.event_id = user_event_agenda_saves.event_id
+    )
+  );
+
+drop policy if exists "Users can delete own agenda saves" on public.user_event_agenda_saves;
+create policy "Users can delete own agenda saves"
+  on public.user_event_agenda_saves
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);
+
+grant select, insert, delete on public.user_event_agenda_saves to authenticated;
+grant select on public.user_event_agenda_saves to service_role;

--- a/supabase/migrations/20260524224453_repair_cleared_attendance_activity.sql
+++ b/supabase/migrations/20260524224453_repair_cleared_attendance_activity.sql
@@ -1,0 +1,9 @@
+-- Remove stale journey activity after an attendance status has been cleared.
+-- Keep bookmarks represented as saved activity and leave speaking roles intact.
+update public.user_events
+set activity_type = case
+  when is_bookmarked = true then 'saved'::user_event_activity_type
+  else null
+end
+where status is null
+  and activity_type in ('attending', 'attended');


### PR DESCRIPTION
## Summary
- add post-attendance mobile event ratings with optional connection-count feedback
- add per-session agenda saves and aggregate networking signals in event detail
- repair stale public attendance activity when attendance has been cleared
- add the agenda-save schema and migration coverage

## Security
- agenda saves are protected by row level security and scoped to the authenticated user's own saves
- aggregate networking pulse reads use the trusted server admin client and apply privacy thresholds before being returned; this PR does not expose a public SECURITY DEFINER aggregate RPC

## Validation
- `npm test -- --run ...` (10 test files, 65 tests passed)
- `npm run type-check:src`
- `npm run type-check:mobile`
- focused `eslint` (passes with 3 non-blocking warnings)
- `git diff --cached --check`
- Supabase local migration/lint commands could not run because local Postgres was not running on port 54322
