### PR TITLE
[codex] Simplify mobile settings integration label

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -35,11 +35,7 @@ import {
   loadMobileGoogleCalendarStatus,
   loadMobileSubscriptionStatus,
 } from "../../src/lib/mobileApi";
-import {
-  formatCareerSummary,
-  formatSubscriptionSummary,
-  hasPaidAccess,
-} from "../../src/lib/settingsPresentation";
+import { formatSubscriptionSummary } from "../../src/lib/settingsPresentation";
 import { useAppTheme } from "../../src/providers/ThemeProvider";
 
 function getVisibilityLabel(value: string): string {
@@ -133,11 +129,6 @@ export default function SettingsScreen() {
       secondary,
     };
   }, [profile, session?.user.email]);
-
-  const careerSummary = useMemo(
-    () => formatCareerSummary(profile?.careerProfile),
-    [profile?.careerProfile],
-  );
 
   async function handleRefresh() {
     setRefreshing(true);
@@ -379,7 +370,7 @@ export default function SettingsScreen() {
               googleCalendarStatus,
               appleCalendarPermission,
             )}
-            title="Calendar integrations"
+            title="Integrations"
           />
           <SettingsDivider />
           <SettingsRow


### PR DESCRIPTION
## Summary
- rename the mobile settings calendar row from `Calendar integrations` to `Integrations`
- remove two unused settings presentation values that made this file fail ESLint
- publish only the minimal one-file change, excluding local formatting churn and already-merged work

## Validation
- `./node_modules/.bin/eslint 'apps/mobile/app/(tabs)/settings.tsx'`
- `npm run type-check:mobile`
- `git diff --cached --check`
